### PR TITLE
feat: add Terra-only tag for legacy-migrated wallets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ google-service-account.json
 # Status updates
 docs/status-update*.superpowers/
 docs/designs/
+
+# Git worktrees
+.worktrees/

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -35,6 +35,7 @@ import keystore, { KeystoreEnum } from 'nativeModules/keystore'
 
 import { settings } from 'utils/storage'
 import { migrateLegacyKeystore } from 'utils/legacyMigration'
+import { backfillTerraOnlyFlag } from 'services/migrateToVault'
 
 import DebugBanner from './DebugBanner'
 import GlobalTopNotification from './GlobalTopNotification'
@@ -186,9 +187,9 @@ export default (): ReactElement => {
   useEffect(() => {
     const startup = async (): Promise<void> => {
       const [, loaded] = await Promise.all([
-        clearKeystoreWhenFirstRun().then(() =>
-          migrateLegacyKeystore()
-        ),
+        clearKeystoreWhenFirstRun()
+          .then(() => migrateLegacyKeystore())
+          .then(() => backfillTerraOnlyFlag()),
         settings.get(),
       ])
       setLocal(loaded)

--- a/src/components/migration/WalletMigrationCard.tsx
+++ b/src/components/migration/WalletMigrationCard.tsx
@@ -23,9 +23,19 @@ export default function WalletMigrationCard({
   return (
     <View style={styles.card} testID={testID}>
       <View style={styles.headerRow}>
-        <Text fontType="brockmann-medium" style={styles.name}>
-          {name}
-        </Text>
+        <View style={styles.nameRow}>
+          <Text fontType="brockmann-medium" style={styles.name}>
+            {name}
+          </Text>
+          <View style={styles.terraOnlyBadge}>
+            <Text
+              fontType="brockmann-medium"
+              style={styles.terraOnlyText}
+            >
+              Terra only
+            </Text>
+          </View>
+        </View>
         <Text fontType="satoshi-medium" style={styles.balance}>
           $0.00
         </Text>
@@ -76,9 +86,24 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
   },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
   name: {
     fontSize: 16,
     color: MIGRATION.textPrimary,
+  },
+  terraOnlyBadge: {
+    backgroundColor: 'rgba(100, 160, 255, 0.2)',
+    borderRadius: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  terraOnlyText: {
+    color: '#64A0FF',
+    fontSize: 11,
   },
   balance: {
     fontSize: 20,

--- a/src/nativeModules/preferences.ts
+++ b/src/nativeModules/preferences.ts
@@ -13,6 +13,7 @@ export enum PreferencesEnum {
   legacyKeystoreMigrated = 'legacyKeystoreMigrated',
   legacyDataFound = 'legacyDataFound',
   vaultsUpgraded = 'vaultsUpgraded',
+  terraOnlyBackfilled = 'terraOnlyBackfilled',
 }
 
 export type PreferencesType = {

--- a/src/screens/WalletPicker.tsx
+++ b/src/screens/WalletPicker.tsx
@@ -91,11 +91,20 @@ export default function WalletPicker(): React.ReactElement {
               {UTIL.truncate(item.address, [10, 6])}
             </Text>
           </View>
-          {isLegacy && (
-            <View style={styles.legacyBadge}>
-              <Text style={styles.legacyBadgeText}>Legacy</Text>
-            </View>
-          )}
+          <View style={styles.badgeRow}>
+            {item.terraOnly && (
+              <View style={styles.terraOnlyBadge}>
+                <Text style={styles.terraOnlyBadgeText}>
+                  Terra only
+                </Text>
+              </View>
+            )}
+            {isLegacy && (
+              <View style={styles.legacyBadge}>
+                <Text style={styles.legacyBadgeText}>Legacy</Text>
+              </View>
+            )}
+          </View>
         </View>
         {isLegacy && (
           <TouchableOpacity
@@ -172,6 +181,18 @@ const styles = StyleSheet.create({
     color: COLORS.textSecondary,
     fontSize: 13,
     marginTop: 4,
+  },
+  badgeRow: { flexDirection: 'row', gap: 6 },
+  terraOnlyBadge: {
+    backgroundColor: 'rgba(100, 160, 255, 0.2)',
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  terraOnlyBadgeText: {
+    color: '#64A0FF',
+    fontSize: 11,
+    fontWeight: '600',
   },
   legacyBadge: {
     backgroundColor: 'rgba(255, 179, 64, 0.2)',

--- a/src/services/migrateToVault.ts
+++ b/src/services/migrateToVault.ts
@@ -221,10 +221,7 @@ export async function backfillTerraOnlyFlag(): Promise<void> {
     await upsertAuthData({ authData })
   }
 
-  await preferences.setBool(
-    PreferencesEnum.terraOnlyBackfilled,
-    true
-  )
+  await preferences.setBool(PreferencesEnum.terraOnlyBackfilled, true)
 }
 
 export { VAULT_KEY_PREFIX, VAULT_STORE_OPTS, vaultStoreKey }

--- a/src/services/migrateToVault.ts
+++ b/src/services/migrateToVault.ts
@@ -10,6 +10,9 @@ import {
   AuthDataValueType,
   LedgerDataValueType,
 } from 'utils/authData'
+import preferences, {
+  PreferencesEnum,
+} from 'nativeModules/preferences'
 import type { KeyImportResult } from './dklsKeyImport'
 
 const VAULT_KEY_PREFIX = 'VAULT-'
@@ -134,6 +137,7 @@ export async function storeFastVault(
           encryptedKey: '',
           password: '',
           ledger: false,
+          terraOnly: true,
         },
       },
     })
@@ -166,6 +170,61 @@ export async function isVaultFastVault(
   } catch {
     return false
   }
+}
+
+/**
+ * One-time backfill: for wallets already migrated to fast vaults before the
+ * `terraOnly` flag existed, inspect their vault's chainPublicKeys and stamp
+ * `terraOnly: true` in authData if the vault only supports Terra.
+ */
+export async function backfillTerraOnlyFlag(): Promise<void> {
+  const done = await preferences.getBool(
+    PreferencesEnum.terraOnlyBackfilled
+  )
+  if (done) return
+
+  const authData = await getAuthData()
+  if (!authData) {
+    await preferences.setBool(
+      PreferencesEnum.terraOnlyBackfilled,
+      true
+    )
+    return
+  }
+
+  let changed = false
+
+  for (const [name, entry] of Object.entries(authData)) {
+    if (entry.ledger) continue
+    const val = entry as AuthDataValueType
+    if (val.terraOnly !== undefined) continue
+
+    const stored = await getStoredVault(name)
+    if (!stored) continue
+
+    try {
+      const vault = fromBinary(VaultSchema, base64.decode(stored))
+      const isTerraOnly =
+        vault.chainPublicKeys.length === 1 &&
+        vault.chainPublicKeys[0].chain === 'Terra'
+
+      if (isTerraOnly) {
+        val.terraOnly = true
+        changed = true
+      }
+    } catch {
+      // Corrupted vault — skip
+    }
+  }
+
+  if (changed) {
+    await upsertAuthData({ authData })
+  }
+
+  await preferences.setBool(
+    PreferencesEnum.terraOnlyBackfilled,
+    true
+  )
 }
 
 export { VAULT_KEY_PREFIX, VAULT_STORE_OPTS, vaultStoreKey }

--- a/src/types/wallet.d.ts
+++ b/src/types/wallet.d.ts
@@ -3,4 +3,5 @@ interface LocalWallet {
   address: string
   ledger: boolean
   path?: number
+  terraOnly?: boolean
 }

--- a/src/utils/authData.ts
+++ b/src/utils/authData.ts
@@ -6,6 +6,7 @@ export type AuthDataValueType = {
   encryptedKey: string
   address: string
   password: string
+  terraOnly?: boolean
 }
 
 export type LedgerDataValueType = {


### PR DESCRIPTION
## Summary

- Adds an explicit `terraOnly` boolean flag to the wallet model (`LocalWallet` + `AuthDataValueType`) to identify wallets migrated from legacy Station storage
- Sets `terraOnly: true` in `storeFastVault()` when migrating a legacy wallet to a fast vault
- Adds a one-time `backfillTerraOnlyFlag()` that runs at startup to stamp existing already-migrated wallets by inspecting their vault's `chainPublicKeys`
- Displays a blue "Terra only" badge on the **Wallet Picker** screen (alongside the existing orange "Legacy" badge when applicable)
- Displays a blue "Terra only" tag on **Wallet Migration Cards** on the "Your wallets" screen

## Test plan

- [ ] Fresh install with no legacy data — no badges shown, backfill completes as no-op
- [ ] Existing legacy wallet not yet migrated — "Legacy" badge shown, no "Terra only" badge yet
- [ ] Migrate a legacy wallet — after migration, "Terra only" badge appears on Wallet Picker
- [ ] Existing already-migrated wallet (pre-backfill) — on first launch after upgrade, backfill stamps `terraOnly: true` and badge appears
- [ ] Wallet created fresh (not from legacy) — no "Terra only" badge shown
- [ ] Migration screen shows "Terra only" tag next to each wallet name

🤖 Generated with [Claude Code](https://claude.com/claude-code)