### PR TITLE
fix(e2e): switch CI to debug build so __DEV__ test shortcuts work

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,7 +89,7 @@ jobs:
             xcode-derived-${{ runner.os }}-${{ hashFiles('package-lock.json', 'app.json') }}-
 
       - name: Build for Detox
-        run: npx detox build --configuration ios.sim.release
+        run: npx detox build --configuration ios.sim.debug
 
       # ── Test ───────────────────────────────────────────────────────
       - name: Boot simulator
@@ -105,7 +105,7 @@ jobs:
           xcrun simctl boot "$DEVICE" || true
 
       - name: Run E2E tests
-        run: npx detox test --configuration ios.sim.release --headless --cleanup
+        run: npx detox test --configuration ios.sim.debug --headless --cleanup
 
       - name: Upload artifacts on failure
         if: failure()

--- a/e2e/import-vault.test.js
+++ b/e2e/import-vault.test.js
@@ -128,7 +128,11 @@ describe('Import Vault', () => {
       });
       execSync(`xcrun simctl boot ${udid}`, { timeout: 120000 });
 
-      await device.launchApp({ delete: true, newInstance: true });
+      await device.launchApp({
+        delete: true,
+        newInstance: true,
+        launchArgs: { detoxURLBlacklistRegex: '.*' },
+      });
       await device.disableSynchronization();
     });
 


### PR DESCRIPTION
## Summary

- **Switch Detox CI from `ios.sim.release` to `ios.sim.debug`** — the E2E tests depend on `__DEV__`-only UI (the `dev-create-fast-vault` button in AuthMenu, Detox file staging in `useImportFlow`) that is hidden in release builds, causing all tests to hang/fail
- **Add missing `detoxURLBlacklistRegex`** to the first test suite's `beforeAll` launch args, matching the pattern already used by `setupWithFixture` — prevents Detox synchronization from blocking on network requests

## Root cause

The CI runs `ios.sim.release`, which sets `__DEV__ = false`. The test's `navigateToMigrationHome()` waits 90s for a button that never renders, then cascades failures through every subsequent test suite. The second suite's `setupWithFixture` then crashes the simulator entirely (FBSOpenApplicationServiceErrorDomain code=4).

## Test plan

- [ ] CI E2E workflow passes on this branch (tests should reach MigrationHome, navigate to ImportVault, and complete the full import flow)
- [ ] Debug build caching still works correctly (prebuild cache is config-agnostic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)