### PR TITLE
fix(ci): increase e2e job timeout to 60 min for uncached builds

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,7 @@ jobs:
   detox:
     name: Detox iOS
     runs-on: macos-latest
-    timeout-minutes: 35
+    timeout-minutes: 60
     env:
       AGENTMAIL_API_KEY: ${{ secrets.AGENTMAIL_API_KEY }}
       AGENTMAIL_EMAIL: ${{ secrets.AGENTMAIL_EMAIL }}


### PR DESCRIPTION
## Summary

- Increase the Detox iOS E2E job `timeout-minutes` from 35 to 60
- When GitHub Actions caches miss (e.g., after dependency changes), the full prebuild + pod install + Xcode build takes ~25 minutes, leaving only ~10 minutes for tests under the old 35-minute limit — not enough
- 60 minutes gives comfortable headroom for uncached builds while still bounding runaway jobs

## Context

The E2E workflow timed out on a recent run due to cache misses:
https://github.com/StationWallet/station-mobile/actions/runs/24337815467/job/71058956151

## Changes

- `.github/workflows/e2e.yml` line 19: `timeout-minutes: 35` → `timeout-minutes: 60`

## Test plan

- [x] Verify the workflow YAML is valid
- [ ] Trigger a test run on this branch (push a path-matched file or re-run manually) and confirm the job completes within the new timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)