### PR TITLE
fix: use full semver for EAS node version

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -18,7 +18,7 @@
     },
     "production": {
       "channel": "production",
-      "node": "20"
+      "node": "20.20.2"
     }
   },
   "submit": {


### PR DESCRIPTION
## Summary
- EAS requires a full semver string (e.g. `20.20.2`), not just `20` — fixes build validation error from #24

## Test plan
- [ ] Verify `eas build --platform android --profile production` passes validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)