### PR TITLE
feat: add feature flag to gate migration flow

### DIFF
--- a/__test__/config/env.test.ts
+++ b/__test__/config/env.test.ts
@@ -1,0 +1,7 @@
+import { MIGRATION_FLOW_ENABLED } from '../../src/config/env'
+
+describe('feature flags', () => {
+  test('MIGRATION_FLOW_ENABLED defaults to false', () => {
+    expect(MIGRATION_FLOW_ENABLED).toBe(false)
+  })
+})

--- a/src/components/migration/InfoCard.tsx
+++ b/src/components/migration/InfoCard.tsx
@@ -3,6 +3,7 @@ import { View, StyleSheet } from 'react-native'
 import Svg, { Path } from 'react-native-svg'
 import { MIGRATION } from 'consts/migration'
 import Text from 'components/Text'
+import { MIGRATION_FLOW_ENABLED } from 'config/env'
 
 function ShieldCheckIcon(): React.ReactElement {
   return (
@@ -84,12 +85,14 @@ export default function InfoCard({
         .
       </Text>
 
-      <View style={styles.countdownRow}>
-        <ClockIcon />
-        <Text fontType="brockmann" style={styles.countdown}>
-          The window closes in {daysRemaining} days.
-        </Text>
-      </View>
+      {MIGRATION_FLOW_ENABLED && (
+        <View style={styles.countdownRow}>
+          <ClockIcon />
+          <Text fontType="brockmann" style={styles.countdown}>
+            The window closes in {daysRemaining} days.
+          </Text>
+        </View>
+      )}
     </View>
   )
 }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -2,3 +2,6 @@ export const env = {
   relayUrl: 'https://api.vultisig.com/router',
   vultisigApiUrl: 'https://api.vultisig.com',
 } as const
+
+/** Set to `true` when the full migration/vault-creation flow is ready to ship. */
+export const MIGRATION_FLOW_ENABLED = false

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -21,6 +21,7 @@ import { WalletNavContext } from './hooks'
 import preferences, {
   PreferencesEnum,
 } from 'nativeModules/preferences'
+import { MIGRATION_FLOW_ENABLED } from 'config/env'
 
 export {
   useWalletCreated,
@@ -52,7 +53,9 @@ export default function AppNavigator(): React.ReactElement | null {
         PreferencesEnum.legacyDataFound
       )
 
-      if (loaded.length > 0 && !vaultsUpgraded && legacyDataFound) {
+      if (!MIGRATION_FLOW_ENABLED) {
+        setRootRoute('Migration')
+      } else if (loaded.length > 0 && !vaultsUpgraded && legacyDataFound) {
         setRootRoute('Migration')
       } else if (loaded.length === 0) {
         // In dev mode, show Auth first so E2E dev seed buttons are accessible.

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -201,7 +201,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   checkBackText: {
-    fontSize: 16,
+    fontSize: 20,
     color: MIGRATION.textTertiary,
     textAlign: 'center' as const,
     paddingVertical: 12,

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -89,29 +89,39 @@ export default function MigrationHome(): React.ReactElement {
             entering={FadeIn.delay(1800).duration(300)}
             style={styles.buttonGroup}
           >
-            <Button
-              title={
-                hasLegacyWallets
-                  ? 'Start Migration'
-                  : 'Create a Fast Vault'
-              }
-              theme="ctaBlue"
-              titleFontType="brockmann-medium"
-              onPress={handleCta}
-              disabled={!MIGRATION_FLOW_ENABLED}
-              containerStyle={styles.ctaButton}
-              testID="migration-cta"
-            />
+            {MIGRATION_FLOW_ENABLED ? (
+              <>
+                <Button
+                  title={
+                    hasLegacyWallets
+                      ? 'Start Migration'
+                      : 'Create a Fast Vault'
+                  }
+                  theme="ctaBlue"
+                  titleFontType="brockmann-medium"
+                  onPress={handleCta}
+                  containerStyle={styles.ctaButton}
+                  testID="migration-cta"
+                />
 
-            <Button
-              title="I already have a Fast Vault"
-              theme="secondaryDark"
-              titleFontType="brockmann-medium"
-              onPress={() => navigation.navigate('ImportVault')}
-              disabled={!MIGRATION_FLOW_ENABLED}
-              containerStyle={styles.secondaryButton}
-              testID="import-vault-button"
-            />
+                <Button
+                  title="I already have a Fast Vault"
+                  theme="secondaryDark"
+                  titleFontType="brockmann-medium"
+                  onPress={() => navigation.navigate('ImportVault')}
+                  containerStyle={styles.secondaryButton}
+                  testID="import-vault-button"
+                />
+              </>
+            ) : (
+              <Text
+                fontType="brockmann-medium"
+                style={styles.checkBackText}
+                testID="check-back-soon"
+              >
+                Check back soon
+              </Text>
+            )}
 
             <TouchableOpacity
               style={styles.linkButton}
@@ -189,6 +199,12 @@ const styles = StyleSheet.create({
     paddingBottom: 24,
     gap: 12,
     alignItems: 'center',
+  },
+  checkBackText: {
+    fontSize: 16,
+    color: MIGRATION.textTertiary,
+    textAlign: 'center' as const,
+    paddingVertical: 12,
   },
   ctaButton: {
     borderRadius: 99,

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -19,6 +19,7 @@ import {
   MigrationWallet,
 } from 'services/migrateToVault'
 import type { MigrationStackParams } from 'navigation/MigrationNavigator'
+import { MIGRATION_FLOW_ENABLED } from 'config/env'
 
 type Nav = StackNavigationProp<MigrationStackParams, 'MigrationHome'>
 
@@ -97,6 +98,7 @@ export default function MigrationHome(): React.ReactElement {
               theme="ctaBlue"
               titleFontType="brockmann-medium"
               onPress={handleCta}
+              disabled={!MIGRATION_FLOW_ENABLED}
               containerStyle={styles.ctaButton}
               testID="migration-cta"
             />
@@ -106,6 +108,7 @@ export default function MigrationHome(): React.ReactElement {
               theme="secondaryDark"
               titleFontType="brockmann-medium"
               onPress={() => navigation.navigate('ImportVault')}
+              disabled={!MIGRATION_FLOW_ENABLED}
               containerStyle={styles.secondaryButton}
               testID="import-vault-button"
             />


### PR DESCRIPTION
## Summary

- Adds a `MIGRATION_FLOW_ENABLED` compile-time flag in `src/config/env.ts` (defaults to `false`)
- When off: all users land on the "Your seed phrase becomes a Fast Vault" page with "Check back soon" text instead of action buttons, and the countdown row is hidden
- When on: the full migration flow works as before
- Pure JS change — can be toggled and shipped via EAS OTA update without a native build

## Test plan

- [ ] Verify app launches to MigrationHome with "Check back soon" text when flag is `false`
- [ ] Verify buttons and countdown reappear when flag is set to `true`
- [ ] Run `npx jest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)