### PR TITLE
feat: centralize dev feature flags with env var toggle

### DIFF
--- a/__mocks__/expo-virtual-env.js
+++ b/__mocks__/expo-virtual-env.js
@@ -1,0 +1,1 @@
+module.exports = { env: {} }

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
   moduleNameMapper: {
     '^react-native-url-polyfill/auto$': '<rootDir>/__mocks__/empty.js',
     '^react-native$': '<rootDir>/__mocks__/react-native.js',
+    '^expo/virtual/env$': '<rootDir>/__mocks__/expo-virtual-env.js',
   },
   testMatch: [
     '**/__tests__/**/*.test.{js,ts,tsx}',

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "expo-camera": "~55.0.0",
         "expo-clipboard": "~55.0.0",
         "expo-crypto": "~55.0.10",
+        "expo-dev-client": "~55.0.27",
         "expo-document-picker": "~55.0.12",
         "expo-file-system": "~55.0.12",
         "expo-local-authentication": "~55.0.0",
@@ -1943,32 +1944,31 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "55.0.12",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.12.tgz",
-      "integrity": "sha512-qVih0IrjupykH/yAUilZqW1RCpqm8TKG8XJabji2VHI1LstGqw0NJAsBjX927yns08u/fFJTwOsB4PYOoq1HiA==",
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.15.tgz",
+      "integrity": "sha512-lHc0ELIQ8126jYOMZpLv3WIuvordW98jFg5aT/J1/12n2ycuXu01XLZkJsdw0avO34cusUYb1It+MvY8JiMduA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~55.0.7",
+        "@expo/config-plugins": "~55.0.8",
         "@expo/config-types": "^55.0.5",
         "@expo/json-file": "^10.0.13",
-        "@expo/require-utils": "^55.0.3",
+        "@expo/require-utils": "^55.0.4",
         "deepmerge": "^4.3.1",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
-        "resolve-from": "^5.0.0",
         "resolve-workspace-root": "^2.0.0",
         "semver": "^7.6.0",
         "slugify": "^1.3.4"
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "55.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.7.tgz",
-      "integrity": "sha512-XZUoDWrsHEkH3yasnDSJABM/UxP5a1ixzRwU/M+BToyn/f0nTrSJJe/Ay/FpxkI4JSNz2n0e06I23b2bleXKVA==",
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.8.tgz",
+      "integrity": "sha512-8WfWTRntTCcowfOS+tHdB0z98gKetTwktg4G5TWkCkXVa8Jt1NUnvzaaU4UHk2vbR2U4N84RyZJFizSwfF6C9g==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-types": "^55.0.5",
-        "@expo/json-file": "~10.0.12",
+        "@expo/json-file": "~10.0.13",
         "@expo/plist": "^0.5.2",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
@@ -2507,9 +2507,9 @@
       }
     },
     "node_modules/@expo/require-utils": {
-      "version": "55.0.3",
-      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.3.tgz",
-      "integrity": "sha512-TS1m5tW45q4zoaTlt6DwmdYHxvFTIxoLrTHKOFrIirHIqIXnHCzpceg8wumiBi+ZXSaGY2gobTbfv+WVhJY6Fw==",
+      "version": "55.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.4.tgz",
+      "integrity": "sha512-JAANvXqV7MOysWeVWgaiDzikoyDjJWOV/ulOW60Zb3kXJfrx2oZOtGtDXDFKD1mXuahQgoM5QOjuZhF7gFRNjA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -2560,9 +2560,9 @@
       }
     },
     "node_modules/@expo/schema-utils": {
-      "version": "55.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-55.0.2.tgz",
-      "integrity": "sha512-QZ5WKbJOWkCrMq0/kfhV9ry8te/OaS34YgLVpG8u9y2gix96TlpRTbxM/YATjNcUR2s4fiQmPCOxkGtog4i37g==",
+      "version": "55.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-55.0.3.tgz",
+      "integrity": "sha512-l9KHVjTo6MvoeyvwNr6AjckGJm8NIcqZ3QSAh51cWozXW9v2AUjyCyqYtFtyntLWRZ0x/ByYJishpQo4ZQq45Q==",
       "license": "MIT"
     },
     "node_modules/@expo/sdk-runtime-versions": {
@@ -10199,6 +10199,57 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-dev-client": {
+      "version": "55.0.27",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-55.0.27.tgz",
+      "integrity": "sha512-Ala2ER6v1NPFySdnuQN/GpQZI9r7E9eSMvzD32vv8A4FJkPfzjvj6U5uH4IytQQLVTa837fknXRvOMwRb9ZYQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-launcher": "55.0.28",
+        "expo-dev-menu": "55.0.23",
+        "expo-dev-menu-interface": "55.0.2",
+        "expo-manifests": "~55.0.15",
+        "expo-updates-interface": "~55.1.5"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher": {
+      "version": "55.0.28",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-55.0.28.tgz",
+      "integrity": "sha512-jwCD7YeGqZMWrS4KODb51kPBDta8bDrPjhYCnodglcQ0jhPVsAnVSbtsQ2/TaaYUUtv+ipm1ufhNTFtcwya9kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/schema-utils": "^55.0.3",
+        "expo-dev-menu": "55.0.23",
+        "expo-manifests": "~55.0.15"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu": {
+      "version": "55.0.23",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-55.0.23.tgz",
+      "integrity": "sha512-m6B2EwkoX9hwzP50EZPX8vc/szGfvNFsUTw3ExTWnxiJ9/IM0WfCFYjt8siFjMHcyblIjBt/XLN6mw6q8m2AEg==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-menu-interface": "55.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu-interface": {
+      "version": "55.0.2",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-55.0.2.tgz",
+      "integrity": "sha512-DomUNvGzY/xliwnMdbAYY780sCv19N7zIbifc0ClcoCzJZpNSCkvJ2qGIFRPyM/7DmqmlHGCKi8di7kYYLKNEg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-document-picker": {
       "version": "55.0.12",
       "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-55.0.12.tgz",
@@ -10267,12 +10318,12 @@
       }
     },
     "node_modules/expo-manifests": {
-      "version": "55.0.13",
-      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-55.0.13.tgz",
-      "integrity": "sha512-eLU5PIF9Tg3hHfKK9NgkvCRxwLb3pn8j2W6G/Vt8R6MHSNgaFU7pujvcBDbJCe5t9109zeS5PJY/d+dcagIKNw==",
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-55.0.15.tgz",
+      "integrity": "sha512-p40ftXpgLTFGddFy35MYZMyjm/E6IQdn3l6fBZZ6zeraEzYLt+VLHYsplOL9ccTYvUSWKN9aOWRpoEYpyGVBVw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~55.0.12",
+        "@expo/config": "~55.0.14",
         "expo-json-utils": "~55.0.2"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "expo-camera": "~55.0.0",
     "expo-clipboard": "~55.0.0",
     "expo-crypto": "~55.0.10",
+    "expo-dev-client": "~55.0.27",
     "expo-document-picker": "~55.0.12",
     "expo-file-system": "~55.0.12",
     "expo-local-authentication": "~55.0.0",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -5,3 +5,14 @@ export const env = {
 
 /** Set to `true` when the full migration/vault-creation flow is ready to ship. */
 export const MIGRATION_FLOW_ENABLED = false
+
+const showDevFeatures =
+  __DEV__ && process.env.EXPO_PUBLIC_SHOW_DEV_FEATURES === 'true'
+
+export const DevFlags = {
+  CryptoTestScreen: showDevFeatures,
+  FullE2ETest: showDevFeatures,
+  SeedLegacyData: showDevFeatures,
+  SeedCorruptData: showDevFeatures,
+  VerifyVault: showDevFeatures,
+} as const

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -3,24 +3,25 @@ import { createStackNavigator } from '@react-navigation/stack'
 import AuthMenu from '../screens/auth/AuthMenu'
 import NewWalletStack from './NewWalletStack'
 import RecoverWalletStack from './RecoverWalletStack'
+import { DevFlags } from '../config/env'
 
-const CryptoTestScreen = __DEV__
+const CryptoTestScreen = DevFlags.CryptoTestScreen
   ? require('../components/CryptoTestScreen').default
   : null
 
-const DevFullE2ETest = __DEV__
+const DevFullE2ETest = DevFlags.FullE2ETest
   ? require('../components/DevFullE2ETest').default
   : null
 
-const DevSeedLegacyData = __DEV__
+const DevSeedLegacyData = DevFlags.SeedLegacyData
   ? require('../components/DevSeedLegacyData').default
   : null
 
-const DevSeedCorruptData = __DEV__
+const DevSeedCorruptData = DevFlags.SeedCorruptData
   ? require('../components/DevSeedCorruptData').default
   : null
 
-const DevVerifyVault = __DEV__
+const DevVerifyVault = DevFlags.VerifyVault
   ? require('../components/DevVerifyVault').default
   : null
 
@@ -35,28 +36,28 @@ export default function AuthNavigator(): React.ReactElement {
         name="RecoverWallet"
         component={RecoverWalletStack}
       />
-      {__DEV__ && CryptoTestScreen && (
+      {CryptoTestScreen && (
         <Stack.Screen
           name="CryptoTest"
           component={CryptoTestScreen}
         />
       )}
-      {__DEV__ && DevFullE2ETest && (
+      {DevFullE2ETest && (
         <Stack.Screen name="FullE2ETest" component={DevFullE2ETest} />
       )}
-      {__DEV__ && DevSeedLegacyData && (
+      {DevSeedLegacyData && (
         <Stack.Screen
           name="SeedLegacyData"
           component={DevSeedLegacyData}
         />
       )}
-      {__DEV__ && DevSeedCorruptData && (
+      {DevSeedCorruptData && (
         <Stack.Screen
           name="SeedCorruptData"
           component={DevSeedCorruptData}
         />
       )}
-      {__DEV__ && DevVerifyVault && (
+      {DevVerifyVault && (
         <Stack.Screen name="VerifyVault" component={DevVerifyVault} />
       )}
     </Stack.Navigator>

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -11,24 +11,25 @@ import type {
   MigrationResult,
 } from 'services/migrateToVault'
 import type { MigrationMode } from './MigrationNavigator'
+import { DevFlags } from '../config/env'
 
-const CryptoTestScreen = __DEV__
+const CryptoTestScreen = DevFlags.CryptoTestScreen
   ? require('../components/CryptoTestScreen').default
   : null
 
-const DevFullE2ETest = __DEV__
+const DevFullE2ETest = DevFlags.FullE2ETest
   ? require('../components/DevFullE2ETest').default
   : null
 
-const DevSeedLegacyData = __DEV__
+const DevSeedLegacyData = DevFlags.SeedLegacyData
   ? require('../components/DevSeedLegacyData').default
   : null
 
-const DevSeedCorruptData = __DEV__
+const DevSeedCorruptData = DevFlags.SeedCorruptData
   ? require('../components/DevSeedCorruptData').default
   : null
 
-const DevVerifyVault = __DEV__
+const DevVerifyVault = DevFlags.VerifyVault
   ? require('../components/DevVerifyVault').default
   : null
 
@@ -74,28 +75,28 @@ export default function MainNavigator(): React.ReactElement {
         name="ExportPrivateKey"
         component={ExportPrivateKey}
       />
-      {__DEV__ && CryptoTestScreen && (
+      {CryptoTestScreen && (
         <Stack.Screen
           name="CryptoTest"
           component={CryptoTestScreen}
         />
       )}
-      {__DEV__ && DevFullE2ETest && (
+      {DevFullE2ETest && (
         <Stack.Screen name="FullE2ETest" component={DevFullE2ETest} />
       )}
-      {__DEV__ && DevSeedLegacyData && (
+      {DevSeedLegacyData && (
         <Stack.Screen
           name="SeedLegacyData"
           component={DevSeedLegacyData}
         />
       )}
-      {__DEV__ && DevSeedCorruptData && (
+      {DevSeedCorruptData && (
         <Stack.Screen
           name="SeedCorruptData"
           component={DevSeedCorruptData}
         />
       )}
-      {__DEV__ && DevVerifyVault && (
+      {DevVerifyVault && (
         <Stack.Screen name="VerifyVault" component={DevVerifyVault} />
       )}
       <Stack.Screen name="Migration" component={MigrationNavigator} />

--- a/src/navigation/MigrationNavigator.tsx
+++ b/src/navigation/MigrationNavigator.tsx
@@ -19,11 +19,13 @@ import type {
 
 export type MigrationMode = 'migrate' | 'create'
 
-const DevSeedLegacyData = __DEV__
+import { DevFlags } from '../config/env'
+
+const DevSeedLegacyData = DevFlags.SeedLegacyData
   ? require('../components/DevSeedLegacyData').default
   : null
 
-const DevSeedCorruptData = __DEV__
+const DevSeedCorruptData = DevFlags.SeedCorruptData
   ? require('../components/DevSeedCorruptData').default
   : null
 
@@ -109,13 +111,13 @@ export default function MigrationNavigator(): React.ReactElement {
         name="MigrationSuccess"
         component={MigrationSuccess}
       />
-      {__DEV__ && DevSeedLegacyData && (
+      {DevSeedLegacyData && (
         <Stack.Screen
           name="SeedLegacyData"
           component={DevSeedLegacyData}
         />
       )}
-      {__DEV__ && DevSeedCorruptData && (
+      {DevSeedCorruptData && (
         <Stack.Screen
           name="SeedCorruptData"
           component={DevSeedCorruptData}

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -55,7 +55,11 @@ export default function AppNavigator(): React.ReactElement | null {
 
       if (!MIGRATION_FLOW_ENABLED) {
         setRootRoute('Migration')
-      } else if (loaded.length > 0 && !vaultsUpgraded && legacyDataFound) {
+      } else if (
+        loaded.length > 0 &&
+        !vaultsUpgraded &&
+        legacyDataFound
+      ) {
         setRootRoute('Migration')
       } else if (loaded.length === 0) {
         // In dev mode, show Auth first so E2E dev seed buttons are accessible.

--- a/src/screens/auth/AuthMenu.tsx
+++ b/src/screens/auth/AuthMenu.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { COLORS } from 'consts/theme'
+import { DevFlags } from '../../config/env'
 import authStyles from './authStyles'
 import { useWalletNav } from 'navigation/hooks'
 
@@ -76,7 +77,7 @@ const AuthMenu = ({
             </Text>
           </TouchableOpacity>
 
-          {__DEV__ && (
+          {DevFlags.FullE2ETest && (
             <>
               {goToMigration && (
                 <TouchableOpacity

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -12,6 +12,7 @@ import type { StackNavigationProp } from '@react-navigation/stack'
 
 import { MIGRATION } from 'consts/migration'
 import Text from 'components/Text'
+import { DevFlags } from '../../config/env'
 import Button from 'components/Button'
 import InfoCard from 'components/migration/InfoCard'
 import {
@@ -136,7 +137,7 @@ export default function MigrationHome(): React.ReactElement {
           </Animated.View>
 
           {/* Dev seed buttons — outside ready gate so they render immediately for E2E tests */}
-          {__DEV__ && (
+          {DevFlags.SeedLegacyData && (
             <View style={styles.devButtons}>
               <TouchableOpacity
                 testID="dev-seed-legacy"
@@ -178,7 +179,7 @@ const styles = StyleSheet.create({
   },
   animationPlaceholder: {
     width: 200,
-    height: __DEV__ ? 40 : 200,
+    height: DevFlags.SeedLegacyData ? 40 : 200,
     alignSelf: 'center',
     marginTop: 92,
   },

--- a/src/screens/migration/MigrationSuccess.tsx
+++ b/src/screens/migration/MigrationSuccess.tsx
@@ -98,7 +98,9 @@ function CheckmarkIcon(): React.ReactElement {
   )
 }
 
-const DevVerifyVault = __DEV__
+import { DevFlags } from '../../config/env'
+
+const DevVerifyVault = DevFlags.VerifyVault
   ? require('components/DevVerifyVault').default
   : null
 
@@ -226,7 +228,7 @@ export default function MigrationSuccess(): React.ReactElement {
         )}
       </View>
 
-      {__DEV__ && DevVerifyVault && (
+      {DevVerifyVault && (
         <DevVerifyVault
           importedVaultName={
             params.importedVaultName ?? params.migratedWalletName


### PR DESCRIPTION
## Summary
- Centralizes all dev UI button visibility (`CryptoTestScreen`, `FullE2ETest`, `SeedLegacyData`, `SeedCorruptData`, `VerifyVault`) into a single `DevFlags` config in `src/config/env.ts`
- Flags are controlled by `EXPO_PUBLIC_SHOW_DEV_FEATURES` env var, **defaulting to off** in dev builds
- Adds `expo-dev-client` for proper hot reload support with custom native modules

## Usage
```bash
# Dev buttons hidden (default)
npx expo start --dev-client

# Dev buttons shown
EXPO_PUBLIC_SHOW_DEV_FEATURES=true npx expo start --dev-client
```

## Test plan
- [ ] Run app without env var — dev buttons should not appear
- [ ] Run with `EXPO_PUBLIC_SHOW_DEV_FEATURES=true` — dev buttons appear
- [ ] Verify hot reload works with `expo-dev-client`
- [ ] Production build unaffected (`__DEV__` gate still applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)