### PR TITLE
Redesign Check back soon migration screen

### DIFF
--- a/src/components/migration/InfoCard.tsx
+++ b/src/components/migration/InfoCard.tsx
@@ -68,13 +68,20 @@ function ClockIcon(): React.ReactElement {
 
 type Props = {
   daysRemaining: number
+  connectedBottom?: boolean
 }
 
 export default function InfoCard({
   daysRemaining,
+  connectedBottom = false,
 }: Props): React.ReactElement {
   return (
-    <View style={styles.card}>
+    <View
+      style={[
+        styles.card,
+        connectedBottom && styles.cardConnectedBottom,
+      ]}
+    >
       <View style={styles.titleRow}>
         <LightningIcon />
         <Text fontType="brockmann-medium" style={styles.title}>
@@ -82,17 +89,17 @@ export default function InfoCard({
         </Text>
       </View>
 
-      <Text fontType="brockmann" style={styles.body}>
+      <Text fontType="brockmann-medium" style={styles.body}>
         Faster transactions. Stronger security.{'\n'}
         One password instead of 12 words.
       </Text>
 
-      <Text fontType="brockmann" style={styles.body}>
+      <Text fontType="brockmann-medium" style={styles.body}>
         Fast Vaults are the next evolution of self-custody, built for
         what&apos;s coming to Station.
       </Text>
 
-      <Text fontType="brockmann" style={styles.body}>
+      <Text fontType="brockmann-medium" style={styles.body}>
         Early explorers get{' '}
         <Text fontType="brockmann-bold" style={styles.bodyBold}>
           Station OG
@@ -125,6 +132,11 @@ const styles = StyleSheet.create({
     padding: MIGRATION.cardPadding,
     gap: 12,
   },
+  cardConnectedBottom: {
+    borderBottomLeftRadius: 0,
+    borderBottomRightRadius: 0,
+    borderBottomWidth: 0,
+  },
   titleRow: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -135,13 +147,14 @@ const styles = StyleSheet.create({
     color: MIGRATION.textPrimary,
   },
   body: {
-    fontSize: 14,
-    lineHeight: 20,
+    fontSize: 13,
+    lineHeight: 18,
     color: MIGRATION.textTertiary,
+    letterSpacing: 0.06,
   },
   bodyBold: {
-    fontSize: 14,
-    lineHeight: 20,
+    fontSize: 13,
+    lineHeight: 18,
     color: MIGRATION.textPrimary,
   },
   countdownRow: {

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -11,6 +11,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useNavigation } from '@react-navigation/native'
 import type { StackNavigationProp } from '@react-navigation/stack'
 
+import Svg, { Path } from 'react-native-svg'
 import { MIGRATION } from 'consts/migration'
 import Text from 'components/Text'
 import { DevFlags } from '../../config/env'
@@ -23,6 +24,27 @@ import {
 } from 'services/migrateToVault'
 import type { MigrationStackParams } from 'navigation/MigrationNavigator'
 import { MIGRATION_FLOW_ENABLED } from 'config/env'
+
+function CalendarClockIcon(): React.ReactElement {
+  return (
+    <Svg width={16} height={16} viewBox="0 0 24 24" fill="none">
+      <Path
+        d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"
+        stroke="#4879fd"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <Path
+        d="M12 6v6l4 2"
+        stroke="#4879fd"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  )
+}
 
 type Nav = StackNavigationProp<MigrationStackParams, 'MigrationHome'>
 
@@ -93,14 +115,31 @@ export default function MigrationHome(): React.ReactElement {
             entering={FadeIn.delay(1200).duration(300)}
             style={styles.cardWrapper}
           >
-            <InfoCard daysRemaining={daysRemaining} />
+            <InfoCard
+              daysRemaining={daysRemaining}
+              connectedBottom={!MIGRATION_FLOW_ENABLED}
+            />
+            {!MIGRATION_FLOW_ENABLED && (
+              <View
+                style={styles.checkBackCard}
+                testID="check-back-soon"
+              >
+                <CalendarClockIcon />
+                <Text
+                  fontType="brockmann-medium"
+                  style={styles.checkBackText}
+                >
+                  Check back soon...
+                </Text>
+              </View>
+            )}
           </Animated.View>
 
           <Animated.View
             entering={FadeIn.delay(1800).duration(300)}
             style={styles.buttonGroup}
           >
-            {MIGRATION_FLOW_ENABLED ? (
+            {MIGRATION_FLOW_ENABLED && (
               <>
                 <Button
                   title={
@@ -124,14 +163,6 @@ export default function MigrationHome(): React.ReactElement {
                   testID="import-vault-button"
                 />
               </>
-            ) : (
-              <Text
-                fontType="brockmann-medium"
-                style={styles.checkBackText}
-                testID="check-back-soon"
-              >
-                Check back soon.
-              </Text>
             )}
 
             <TouchableOpacity
@@ -200,7 +231,7 @@ const styles = StyleSheet.create({
     color: MIGRATION.textPrimary,
     textAlign: 'center',
     marginTop: 16,
-    marginBottom: 16,
+    marginBottom: 28,
     lineHeight: 24,
     letterSpacing: -0.36,
   },
@@ -213,11 +244,23 @@ const styles = StyleSheet.create({
     gap: 12,
     alignItems: 'center',
   },
+  checkBackCard: {
+    backgroundColor: MIGRATION.surface1,
+    borderBottomLeftRadius: MIGRATION.radiusCard,
+    borderBottomRightRadius: MIGRATION.radiusCard,
+    paddingTop: 16,
+    paddingBottom: 14,
+    paddingHorizontal: 32,
+    flexDirection: 'row' as const,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+    gap: 8,
+  },
   checkBackText: {
-    fontSize: 20,
-    color: MIGRATION.textTertiary,
-    textAlign: 'center' as const,
-    paddingVertical: 12,
+    fontSize: 13,
+    color: MIGRATION.textPrimary,
+    lineHeight: 18,
+    letterSpacing: 0.06,
   },
   ctaButton: {
     borderRadius: 99,

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -88,10 +88,7 @@ export default function MigrationHome(): React.ReactElement {
 
   return (
     <View
-      style={[
-        styles.container,
-        { paddingBottom: insets.bottom },
-      ]}
+      style={[styles.container, { paddingBottom: insets.bottom }]}
     >
       <ScrollView
         contentContainerStyle={styles.scrollContent}

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -90,14 +90,14 @@ export default function MigrationHome(): React.ReactElement {
     <View
       style={[
         styles.container,
-        { paddingTop: insets.top, paddingBottom: insets.bottom },
+        { paddingBottom: insets.bottom },
       ]}
     >
       <ScrollView
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
       >
-        <View style={styles.content}>
+        <View style={[styles.content, { paddingTop: insets.top }]}>
           <Animated.View
             entering={FadeIn.delay(0).duration(300)}
             style={styles.animationPlaceholder}


### PR DESCRIPTION
## Summary
- Redesign the "Check back soon" migration screen to match Figma specs: styled banner card with clock icon, primary-color text, and `surface1` background connected to InfoCard
- Update InfoCard body text to match Figma (13px medium weight, 18px line height)
- Fix status bar background regression by moving safe area padding inside scroll content

## Test plan
- [ ] Verify "Check back soon" screen matches Figma design (with `MIGRATION_FLOW_ENABLED = false`)
- [ ] Verify status bar area has uniform background with no visible bar
- [ ] Verify migration flow screens still work correctly when `MIGRATION_FLOW_ENABLED = true`
- [ ] Check InfoCard text rendering on both iOS and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)