### PR TITLE
fix: update Vault security docs link

### DIFF
--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -166,7 +166,7 @@ export default function MigrationHome(): React.ReactElement {
               style={styles.linkButton}
               onPress={() => {
                 Linking.openURL(
-                  'https://docs.vultisig.com/security-and-technology/security-technology'
+                  'https://docs.vultisig.com/getting-started/getting-started#what-makes-vultisig-different'
                 )
               }}
             >


### PR DESCRIPTION
## Summary
- Updated the "Learn more about Vault security" hyperlink URL in `MigrationHome.tsx`
- Old URL: `https://docs.vultisig.com/security-and-technology/security-technology`
- New URL: `https://docs.vultisig.com/getting-started/getting-started#what-makes-vultisig-different`

## Test plan
- [ ] Tap "Learn more about Vault security" link on the migration home screen and verify it opens the correct docs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)