### PR TITLE
fix: add Android 16 KB page size support

### DIFF
--- a/app.json
+++ b/app.json
@@ -59,7 +59,15 @@
       "@config-plugins/detox",
       "expo-sharing",
       "expo-updates",
-      "expo-document-picker"
+      "expo-document-picker",
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "pageSizeCompat": true
+          }
+        }
+      ]
     ],
     "extra": {
       "eas": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "date-fns": "^2.23.0",
         "events": "^3.3.0",
         "expo": "~55.0.15",
+        "expo-build-properties": "~55.0.13",
         "expo-camera": "~55.0.15",
         "expo-clipboard": "~55.0.13",
         "expo-crypto": "~55.0.14",
@@ -1562,6 +1563,33 @@
       },
       "peerDependencies": {
         "expo": "^53"
+      }
+    },
+    "node_modules/@config-plugins/detox/node_modules/expo-build-properties": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-0.13.3.tgz",
+      "integrity": "sha512-gw7AYP+YF50Gr912BedelRDTfR4GnUEn9p5s25g4nv0hTJGWpBZdCYR5/Oi2rmCHJXxBqhPjxzV7JRh72fntLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "semver": "^7.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/@config-plugins/detox/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -8768,13 +8796,13 @@
       }
     },
     "node_modules/expo-build-properties": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-0.13.3.tgz",
-      "integrity": "sha512-gw7AYP+YF50Gr912BedelRDTfR4GnUEn9p5s25g4nv0hTJGWpBZdCYR5/Oi2rmCHJXxBqhPjxzV7JRh72fntLg==",
-      "dev": true,
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-55.0.13.tgz",
+      "integrity": "sha512-UYZhUKyh7YQhbJdkBvo68WUQ7fOtZeSV7F8kfYkjEiN/ADRHG0WfEIiddvGfi9cH/5iwpptv/+Lu5cx6uvfegA==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^8.11.0",
+        "@expo/schema-utils": "^55.0.3",
+        "resolve-from": "^5.0.0",
         "semver": "^7.6.0"
       },
       "peerDependencies": {
@@ -8785,7 +8813,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "date-fns": "^2.23.0",
     "events": "^3.3.0",
     "expo": "~55.0.15",
+    "expo-build-properties": "~55.0.13",
     "expo-camera": "~55.0.15",
     "expo-clipboard": "~55.0.13",
     "expo-crypto": "~55.0.14",


### PR DESCRIPTION
## Summary
- Adds `expo-build-properties` plugin with `pageSizeCompat: true` to comply with Google Play's 16 KB memory page size requirement (enforced Nov 1, 2025)
- Without this, app updates will be rejected by Google Play

## Context
Google Play policy requires apps targeting API 35+ to declare 16 KB page size support. The app already targets API 36, but was missing the `android:pageSizeCompat` manifest attribute. The `expo-build-properties` plugin injects this during `expo prebuild`.

## Test plan
- [ ] Run `npx expo prebuild --platform android` and verify `android:pageSizeCompat="true"` appears in the generated `AndroidManifest.xml`
- [ ] Build Android APK/AAB and verify it passes Google Play's pre-launch report

🤖 Generated with [Claude Code](https://claude.com/claude-code)