### PR TITLE
fix: override expo-build-properties to resolve EAS build fingerprint mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1565,33 +1565,6 @@
         "expo": "^53"
       }
     },
-    "node_modules/@config-plugins/detox/node_modules/expo-build-properties": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-0.13.3.tgz",
-      "integrity": "sha512-gw7AYP+YF50Gr912BedelRDTfR4GnUEn9p5s25g4nv0hTJGWpBZdCYR5/Oi2rmCHJXxBqhPjxzV7JRh72fntLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.11.0",
-        "semver": "^7.6.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/@config-plugins/detox/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@dabh/diagnostics": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,9 @@
     "rive-react-native": "^9.8.1",
     "stream-browserify": "^3.0.0"
   },
+  "overrides": {
+    "expo-build-properties": "~55.0.13"
+  },
   "devDependencies": {
     "@babel/core": "^7.24.0",
     "@babel/runtime": "^7.24.0",


### PR DESCRIPTION
## Summary
- Adds an npm `overrides` entry to force `expo-build-properties@~55.0.13` across all dependencies
- `@config-plugins/detox@11.0.0` depends on `expo-build-properties@^0.13.1`, which npm resolves to `0.13.3` — conflicting with the root SDK 55 requirement (`~55.0.13`)
- This version mismatch causes the fingerprint-based `runtimeVersion` to differ between local and EAS builds, failing the "Configure expo-updates" build phase

## Test plan
- [x] `npm ls expo-build-properties` shows single `55.0.13` with no duplicates
- [ ] EAS production Android build succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)