### PR TITLE
ui: align MigrationHome with Figma design

### DIFF
--- a/src/components/migration/BackgroundGlow.tsx
+++ b/src/components/migration/BackgroundGlow.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { Dimensions, StyleSheet, View } from 'react-native'
+import Svg, {
+  Defs,
+  Ellipse,
+  LinearGradient,
+  RadialGradient,
+  Stop,
+} from 'react-native-svg'
+
+const { width: SCREEN_WIDTH } = Dimensions.get('window')
+
+/**
+ * Three blurred gradient ellipses that create the subtle blue glow
+ * behind the MigrationHome screen, matching the Figma design.
+ *
+ * Since React Native lacks CSS blur/blend-modes, we approximate with
+ * SVG radial/linear gradients and opacity.
+ */
+export default function BackgroundGlow(): React.ReactElement {
+  const SVG_H = 500
+  const cx = SCREEN_WIDTH / 2
+
+  return (
+    <View style={styles.container} pointerEvents="none">
+      <Svg
+        width={SCREEN_WIDTH}
+        height={SVG_H}
+        viewBox={`0 0 ${SCREEN_WIDTH} ${SVG_H}`}
+        style={StyleSheet.absoluteFill}
+      >
+        <Defs>
+          {/* Ellipse 2922 — largest, dark navy glow */}
+          <RadialGradient id="glow1" cx="50%" cy="50%" rx="50%" ry="50%">
+            <Stop offset="0%" stopColor="#061B3A" stopOpacity="1" />
+            <Stop offset="70%" stopColor="#061B3A" stopOpacity="0.4" />
+            <Stop offset="100%" stopColor="#02122B" stopOpacity="0" />
+          </RadialGradient>
+
+          {/* Ellipse 2924 — medium, dark-to-blue gradient */}
+          <LinearGradient id="glow2" x1="0" y1="0" x2="0" y2="1">
+            <Stop offset="0%" stopColor="#000409" stopOpacity="0.6" />
+            <Stop offset="100%" stopColor="#052E6F" stopOpacity="0.5" />
+          </LinearGradient>
+
+          {/* Ellipse 2923 — smallest, bright blue glow (color-dodge approx) */}
+          <RadialGradient id="glow3" cx="50%" cy="50%" rx="50%" ry="50%">
+            <Stop offset="0%" stopColor="#084BFF" stopOpacity="0.35" />
+            <Stop offset="60%" stopColor="#084BFF" stopOpacity="0.15" />
+            <Stop offset="85%" stopColor="#9EB8FF" stopOpacity="0.05" />
+            <Stop offset="100%" stopColor="#02122B" stopOpacity="0" />
+          </RadialGradient>
+        </Defs>
+
+        {/* Ellipse 2922: 564x1272, centered, top: -956 -> visible portion starts near top */}
+        <Ellipse cx={cx} cy={-220} rx={282} ry={636} fill="url(#glow1)" />
+
+        {/* Ellipse 2924: 513x619.5, centered, top: -374 */}
+        <Ellipse cx={cx} cy={-65} rx={256} ry={310} fill="url(#glow2)" />
+
+        {/* Ellipse 2923: 189x223.5, centered, top: 44.5 — the bright blue core */}
+        <Ellipse cx={cx} cy={156} rx={95} ry={112} fill="url(#glow3)" />
+      </Svg>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    overflow: 'hidden',
+  },
+})

--- a/src/components/migration/InfoCard.tsx
+++ b/src/components/migration/InfoCard.tsx
@@ -13,7 +13,7 @@ import { MIGRATION_FLOW_ENABLED } from 'config/env'
 
 function LightningIcon(): React.ReactElement {
   return (
-    <Svg width={24} height={24} viewBox="24 7 32 32" fill="none">
+    <Svg width={25} height={25} viewBox="24 7 32 32" fill="none">
       <Defs>
         <LinearGradient
           id="boltGrad"
@@ -34,7 +34,7 @@ function LightningIcon(): React.ReactElement {
         r={12.9}
         stroke="white"
         strokeOpacity={0.1}
-        strokeWidth={1.4}
+        strokeWidth={2.87}
         fill="none"
       />
       <Path
@@ -76,45 +76,50 @@ export default function InfoCard({
   connectedBottom = false,
 }: Props): React.ReactElement {
   return (
-    <View
-      style={[
-        styles.card,
-        connectedBottom && styles.cardConnectedBottom,
-      ]}
-    >
-      <View style={styles.titleRow}>
-        <LightningIcon />
-        <Text fontType="brockmann-medium" style={styles.title}>
-          A new type of wallet
+    <View>
+      {/* Main card */}
+      <View
+        style={[
+          styles.card,
+          connectedBottom && styles.cardConnectedBottom,
+          MIGRATION_FLOW_ENABLED && styles.cardWithCountdown,
+        ]}
+      >
+        <View style={styles.titleRow}>
+          <LightningIcon />
+          <Text fontType="brockmann-medium" style={styles.title}>
+            A new type of wallet
+          </Text>
+        </View>
+
+        <Text fontType="brockmann-medium" style={styles.body}>
+          Faster transactions. Stronger security.{'\n'}
+          One password instead of 12 words.
+        </Text>
+
+        <Text fontType="brockmann-medium" style={styles.body}>
+          Fast Vaults are the next evolution of self-custody, built for
+          what&apos;s coming to Station.
+        </Text>
+
+        <Text fontType="brockmann-medium" style={styles.body}>
+          Early explorers get{' '}
+          <Text fontType="brockmann-bold" style={styles.bodyBold}>
+            Station OG
+          </Text>{' '}
+          status and a{' '}
+          <Text fontType="brockmann-bold" style={styles.bodyBold}>
+            $VULT airdrop
+          </Text>
+          .
         </Text>
       </View>
 
-      <Text fontType="brockmann-medium" style={styles.body}>
-        Faster transactions. Stronger security.{'\n'}
-        One password instead of 12 words.
-      </Text>
-
-      <Text fontType="brockmann-medium" style={styles.body}>
-        Fast Vaults are the next evolution of self-custody, built for
-        what&apos;s coming to Station.
-      </Text>
-
-      <Text fontType="brockmann-medium" style={styles.body}>
-        Early explorers get{' '}
-        <Text fontType="brockmann-bold" style={styles.bodyBold}>
-          Station OG
-        </Text>{' '}
-        status and a{' '}
-        <Text fontType="brockmann-bold" style={styles.bodyBold}>
-          $VULT airdrop
-        </Text>
-        .
-      </Text>
-
+      {/* Bottom strip with countdown */}
       {MIGRATION_FLOW_ENABLED && (
-        <View style={styles.countdownRow}>
+        <View style={styles.countdownStrip}>
           <ClockIcon />
-          <Text fontType="brockmann" style={styles.countdown}>
+          <Text fontType="brockmann-medium" style={styles.countdown}>
             The window closes in {daysRemaining} days.
           </Text>
         </View>
@@ -129,7 +134,8 @@ const styles = StyleSheet.create({
     borderColor: MIGRATION.borderLight,
     borderWidth: 1,
     borderRadius: MIGRATION.radiusCard,
-    padding: MIGRATION.cardPadding,
+    paddingVertical: 20,
+    paddingHorizontal: 16,
     gap: 12,
   },
   cardConnectedBottom: {
@@ -137,13 +143,20 @@ const styles = StyleSheet.create({
     borderBottomRightRadius: 0,
     borderBottomWidth: 0,
   },
+  cardWithCountdown: {
+    borderBottomLeftRadius: 20,
+    borderBottomRightRadius: 20,
+    borderBottomWidth: 0,
+  },
   titleRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 8,
+    gap: 12,
   },
   title: {
     fontSize: 15,
+    lineHeight: 17,
+    letterSpacing: -0.18,
     color: MIGRATION.textPrimary,
   },
   body: {
@@ -157,17 +170,22 @@ const styles = StyleSheet.create({
     lineHeight: 18,
     color: MIGRATION.textPrimary,
   },
-  countdownRow: {
+  countdownStrip: {
+    backgroundColor: MIGRATION.surface1,
+    borderBottomLeftRadius: MIGRATION.radiusCard,
+    borderBottomRightRadius: MIGRATION.radiusCard,
+    paddingTop: 32,
+    paddingBottom: 14,
+    paddingHorizontal: 32,
     flexDirection: 'row',
     alignItems: 'center',
+    justifyContent: 'center',
     gap: 8,
-    marginTop: 4,
-    paddingTop: 12,
-    borderTopWidth: 1,
-    borderTopColor: MIGRATION.borderLight,
   },
   countdown: {
-    fontSize: 13,
-    color: MIGRATION.textTertiary,
+    fontSize: 12,
+    lineHeight: 16,
+    color: MIGRATION.textPrimary,
+    textAlign: 'center',
   },
 })

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -18,6 +18,7 @@ import { DevFlags } from '../../config/env'
 import Button from 'components/Button'
 import InfoCard from 'components/migration/InfoCard'
 import RocketWithGlow from 'components/migration/RocketWithGlow'
+import BackgroundGlow from 'components/migration/BackgroundGlow'
 import {
   discoverLegacyWallets,
   MigrationWallet,
@@ -87,19 +88,23 @@ export default function MigrationHome(): React.ReactElement {
   }
 
   return (
-    <View
-      style={[styles.container, { paddingBottom: insets.bottom }]}
-    >
+    <View style={[styles.container, { paddingBottom: insets.bottom }]}>
+      <BackgroundGlow />
+
       <ScrollView
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
       >
-        <View style={[styles.content, { paddingTop: insets.top }]}>
+        <View style={styles.content}>
+          {/* Rive animation: 200x200, top ~92px from screen top */}
           <Animated.View
             entering={FadeIn.delay(0).duration(300)}
-            style={styles.animationPlaceholder}
+            style={[
+              styles.animationPlaceholder,
+              { marginTop: Math.max(0, 92 - insets.top) },
+            ]}
           >
-            <RocketWithGlow size={140} />
+            <RocketWithGlow size={200} />
           </Animated.View>
 
           <Animated.View entering={FadeIn.delay(600).duration(300)}>
@@ -170,7 +175,7 @@ export default function MigrationHome(): React.ReactElement {
                 )
               }}
             >
-              <Text fontType="brockmann" style={styles.linkText}>
+              <Text fontType="brockmann-medium" style={styles.linkText}>
                 Learn more about Vault security
               </Text>
             </TouchableOpacity>
@@ -219,15 +224,14 @@ const styles = StyleSheet.create({
   },
   animationPlaceholder: {
     width: 200,
-    height: DevFlags.SeedLegacyData ? 40 : 140,
+    height: DevFlags.SeedLegacyData ? 40 : 200,
     alignSelf: 'center',
-    marginTop: 48,
   },
   title: {
     fontSize: 22,
     color: MIGRATION.textPrimary,
     textAlign: 'center',
-    marginTop: 16,
+    marginTop: 28,
     marginBottom: 28,
     lineHeight: 24,
     letterSpacing: -0.36,
@@ -238,14 +242,14 @@ const styles = StyleSheet.create({
   buttonGroup: {
     marginTop: 'auto',
     paddingBottom: 24,
-    gap: 12,
+    gap: 16,
     alignItems: 'center',
   },
   checkBackCard: {
     backgroundColor: MIGRATION.surface1,
     borderBottomLeftRadius: MIGRATION.radiusCard,
     borderBottomRightRadius: MIGRATION.radiusCard,
-    paddingTop: 16,
+    paddingTop: 32,
     paddingBottom: 14,
     paddingHorizontal: 32,
     flexDirection: 'row' as const,
@@ -254,28 +258,29 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   checkBackText: {
-    fontSize: 13,
+    fontSize: 12,
     color: MIGRATION.textPrimary,
-    lineHeight: 18,
-    letterSpacing: 0.06,
+    lineHeight: 16,
   },
   ctaButton: {
-    borderRadius: 99,
-    height: 46,
+    borderRadius: MIGRATION.radiusPill,
+    height: MIGRATION.ctaHeight,
     width: '100%',
   },
   secondaryButton: {
-    borderRadius: 99,
-    height: 46,
+    borderRadius: MIGRATION.radiusPill,
+    height: MIGRATION.ctaHeight,
     width: '100%',
   },
   linkButton: {
     paddingVertical: 8,
+    alignItems: 'center',
   },
   linkText: {
     fontSize: 14,
     color: MIGRATION.textTertiary,
     textDecorationLine: 'underline',
+    textAlign: 'center',
   },
   devButtons: {
     marginTop: 12,


### PR DESCRIPTION
## Summary
- Add SVG gradient background glow (3 layered ellipses matching Figma's blurred gradient layers)
- Increase Rive animation to 200x200px, positioned 92px from screen top
- Split InfoCard: main card (border-radius 24/24/20/20) + separate bottom countdown strip (#061B3A background)
- Match all typography specs: font sizes, weights, line-heights, letter-spacing, colors
- Fix button gap to 16px, center "Learn more" link, use MIGRATION constants for radii/heights
- Lightning icon stroke width 2.87px, icon size 25x25px per Figma

No business logic changes. Navigation, wallet discovery, MIGRATION_FLOW_ENABLED flag, and dev buttons are untouched.

## Test plan
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Biome lint passes
- [ ] Visual comparison with Figma on device/simulator
- [ ] Both MIGRATION_FLOW_ENABLED true/false states render correctly
- [ ] Dev buttons still appear when SeedLegacyData flag is on

Agent-generated