### PR TITLE
fix: defer vault persistence until email verify to prevent funds lock

### DIFF
--- a/src/navigation/MigrationNavigator.tsx
+++ b/src/navigation/MigrationNavigator.tsx
@@ -35,6 +35,7 @@ import type {
   MigrationWallet,
   MigrationResult,
 } from 'services/migrateToVault'
+import type { KeyImportResult } from 'services/dklsKeyImport'
 
 export type MigrationMode = 'migrate' | 'create'
 
@@ -82,7 +83,7 @@ export type MigrationStackParams = {
     results?: MigrationResult[]
     mode: MigrationMode
     email: string
-    publicKey: string
+    keyImportResult: KeyImportResult
   }
   ImportVault: undefined
   MigrationSuccess: {

--- a/src/screens/migration/KeygenProgress.tsx
+++ b/src/screens/migration/KeygenProgress.tsx
@@ -35,7 +35,6 @@ import {
   KeyImportResult,
   KeyImportProgress,
 } from 'services/dklsKeyImport'
-import { storeFastVault } from 'services/migrateToVault'
 import { getAuthDataValue, AuthDataValueType } from 'utils/authData'
 import { decrypt } from 'utils/crypto'
 import { randomHex } from 'utils/mpcCrypto'
@@ -186,8 +185,10 @@ export default function KeygenProgress(): React.ReactElement {
         })
       }
 
-      await storeFastVault(walletName, result)
-
+      // Defer persisting the vault (and stripping legacy authData) until
+      // after the user verifies their email — the server only activates the
+      // co-signer on verify, so writing before then risks a funds-lock if
+      // verification fails or the app dies between keygen and verify.
       navigation.navigate('VerifyEmail', {
         walletName,
         walletIndex,
@@ -195,7 +196,7 @@ export default function KeygenProgress(): React.ReactElement {
         results,
         mode,
         email,
-        publicKey: result.publicKey,
+        keyImportResult: result,
       })
     } catch (err) {
       if (controller.signal.aborted) return

--- a/src/screens/migration/MigrationSuccess.tsx
+++ b/src/screens/migration/MigrationSuccess.tsx
@@ -98,11 +98,17 @@ export default function MigrationSuccess(): React.ReactElement {
 
   // Write the flag eagerly when this screen mounts (not just on tap)
   // so it persists even if the app is killed before the user taps Continue.
-  // vaultsUpgraded means "user has been through the migration flow",
-  // not "all wallets are upgraded" — set it regardless of partial failure.
+  // Only set if the user actually succeeded at something — migrated a wallet,
+  // created a new vault, or imported a backup. If every attempt was skipped
+  // the user should re-enter the migration flow on the next launch.
   useEffect(() => {
-    preferences.setBool(PreferencesEnum.vaultsUpgraded, true)
-  }, [])
+    const anyMigrated =
+      params.results?.some((r) => r.success) ?? false
+    const importedVault = !!params.importedVaultName
+    if (anyMigrated || importedVault) {
+      preferences.setBool(PreferencesEnum.vaultsUpgraded, true)
+    }
+  }, [params.results, params.importedVaultName])
 
   const insets = useSafeAreaInsets()
 

--- a/src/screens/migration/VerifyEmail.tsx
+++ b/src/screens/migration/VerifyEmail.tsx
@@ -23,6 +23,7 @@ import Svg, { Path } from 'react-native-svg'
 import Text from 'components/Text'
 import { MIGRATION } from 'consts/migration'
 import { verifyVaultEmail } from 'services/fastVaultServer'
+import { storeFastVault } from 'services/migrateToVault'
 import { advanceToNextWallet } from 'utils/migrationNav'
 import { getErrorMessage } from 'utils/getErrorMessage'
 import type { MigrationStackParams } from 'navigation/MigrationNavigator'
@@ -63,7 +64,7 @@ export default function VerifyEmail(): React.ReactElement {
     wallets = [],
     results = [],
     email,
-    publicKey,
+    keyImportResult,
   } = route.params
 
   const [code, setCode] = useState('')
@@ -85,20 +86,8 @@ export default function VerifyEmail(): React.ReactElement {
 
       try {
         await verifyVaultEmail({
-          public_key: publicKey,
+          public_key: keyImportResult.publicKey,
           code: verifyCode,
-        })
-        advanceToNextWallet(navigation, {
-          wallets,
-          results,
-          newResult: {
-            wallet: wallets[walletIndex] ?? {
-              name: walletName,
-              address: '',
-              ledger: false,
-            },
-            success: true,
-          },
         })
       } catch (err) {
         const msg = getErrorMessage(err)
@@ -106,9 +95,51 @@ export default function VerifyEmail(): React.ReactElement {
         setCode('')
         setVerifying(false)
         setTimeout(() => inputRef.current?.focus(), 100)
+        return
       }
+
+      // Verification succeeded — now persist the vault locally and strip
+      // legacy auth data. Doing this after verify means a failure at any
+      // earlier point leaves the legacy wallet recoverable.
+      try {
+        await storeFastVault(walletName, keyImportResult)
+      } catch (err) {
+        // Vault activation succeeded on the server but local persistence
+        // failed. The legacy key is still on-device, so the user isn't
+        // locked out — surface the error and let them retry.
+        const msg = getErrorMessage(err)
+        Alert.alert(
+          'Could not save vault',
+          `${msg}\n\nYour legacy wallet is unchanged. Please try again.`
+        )
+        setCode('')
+        setVerifying(false)
+        setTimeout(() => inputRef.current?.focus(), 100)
+        return
+      }
+
+      advanceToNextWallet(navigation, {
+        wallets,
+        results,
+        newResult: {
+          wallet: wallets[walletIndex] ?? {
+            name: walletName,
+            address: '',
+            ledger: false,
+          },
+          success: true,
+        },
+      })
     },
-    [publicKey, verifying, wallets, walletIndex, navigation, results]
+    [
+      keyImportResult,
+      walletName,
+      verifying,
+      wallets,
+      walletIndex,
+      navigation,
+      results,
+    ]
   )
 
   const handleChangeText = useCallback(


### PR DESCRIPTION
## Summary

Fixes the P0 funds-lock risk in the Station → Fast Vault migration flow and the related P1 issues surfaced during review.

### P0: Vault persistence ran before email verify

`storeFastVault` previously ran in `KeygenProgress` immediately after the MPC ceremony — writing the vault to `SecureStore` and blanking `encryptedKey` / `password` from legacy `authData` — and *then* navigated to `VerifyEmail`. But per the VerifyEmail copy (*"This will activate the co-signer"*), the server only activates its share on successful verify. Any failure between the two — app kill, network loss, user backgrounding, dismissal — left the wallet unsignable:

- legacy key blanked from device,
- server-side co-signer not yet activated,
- no UI path back to VerifyEmail for a stuck vault.

The retry path made it worse: a second trip through `KeygenProgress` ran a fresh ceremony (new server share / new pubkey), `storeFastVault`'s `isVaultFastVault` guard skipped the local write, and email verify then activated a server share that didn't match the on-device vault — mismatched shares = permanent loss.

**Fix:** pass the full `KeyImportResult` through navigation params and only call `storeFastVault` *after* `verifyVaultEmail` succeeds. If anything fails at or before verify, no local state has changed and the legacy wallet is still usable.

### P1a: "Use a different email" back-path

Resolved implicitly by the P0 fix. Because nothing is persisted until after verify, going back to change email and re-running keygen is now non-destructive — the new result simply supersedes the old one in memory.

### P1b: `vaultsUpgraded` set unconditionally

`MigrationSuccess` set `vaultsUpgraded = true` on mount regardless of outcome, so a user who skipped every wallet could never re-enter the migration flow via the root router. Now only sets the flag when at least one result actually succeeded, or when a vault was imported. Users who skip everything will re-enter on next launch and can try again.

## Files changed

- `src/navigation/MigrationNavigator.tsx` — `VerifyEmail` params: `publicKey: string` → `keyImportResult: KeyImportResult`
- `src/screens/migration/KeygenProgress.tsx` — drop `storeFastVault` call, pass full result
- `src/screens/migration/VerifyEmail.tsx` — call `storeFastVault` after successful verify, with its own error branch (legacy key still intact on failure)
- `src/screens/migration/MigrationSuccess.tsx` — gate `vaultsUpgraded` on success/import

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on modified files
- [ ] Manual: happy-path migration (one legacy wallet) — expect Fast Vault chip after success
- [ ] Manual: kill app on `VerifyEmail` screen before entering code — relaunch, re-enter flow, verify legacy wallet still migratable
- [ ] Manual: fail verify with wrong code 3x — verify `encryptedKey` in authData is untouched (inspect via dev tools)
- [ ] Manual: skip every wallet → MigrationSuccess → relaunch app → expect migration flow to run again (not routed to Main)
- [ ] Manual: import-vault path still reaches MigrationSuccess and sets `vaultsUpgraded`
- [ ] E2E: run `fast-vault-migration.test.js` (happy path)
- [ ] E2E: run `fast-vault-partial-migration.test.js` (skip/retry UI)

## Notes / deferred

- "Use a different email" on `VerifyEmail` still only `goBack()`s one screen (onto a completed KeygenProgress). Not dangerous anymore post-fix, but the UX could be improved to pop directly back to `VaultEmail`. Left for a separate PR.
- No analytics on migration failures — worth adding so we can see how many users actually hit retry/skip in production.
- The orphan server-side keyshare left behind when a user retries with a different email is a server-side cleanup concern, not a client correctness one.

See \`docs/status-update-2026-04-16.md\` for the broader review that surfaced these issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)