### PR TITLE
chore(ios): bump iOS buildNumber to 3 for TestFlight

### DIFF
--- a/app.json
+++ b/app.json
@@ -27,7 +27,7 @@
       "supportsTablet": true,
       "bundleIdentifier": "money.terra.station",
       "appleTeamId": "4268K8DFX6",
-      "buildNumber": "1",
+      "buildNumber": "3",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       },


### PR DESCRIPTION
## Summary
- Bumps `ios.buildNumber` in `app.json` from `1` to `3` so the next EAS production build can be submitted to TestFlight without a version collision (builds 1 and 2 already exist on App Store Connect).

## Test plan
- [ ] Merge, then run `eas build -p ios --profile production --auto-submit` from `main`
- [ ] Confirm build uploads to TestFlight successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)