### PR TITLE
chore(ios): bump version to 5.0.0 for Vultisig rebrand

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Vultisig",
     "slug": "vultisig",
-    "version": "1.0.0",
+    "version": "5.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -27,7 +27,7 @@
       "supportsTablet": true,
       "bundleIdentifier": "money.terra.station",
       "appleTeamId": "4268K8DFX6",
-      "buildNumber": "3",
+      "buildNumber": "1",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       },


### PR DESCRIPTION
## Summary
- Bumps `expo.version` in `app.json` from `1.0.0` to `5.0.0` and resets `ios.buildNumber` to `1`.
- Unblocks TestFlight submission: the legacy Station Wallet (Terra Station) app on the same bundle ID (`money.terra.station`) already used versions up to 4.0.0 (with builds 4/6/7 on TestFlight). Apple enforces monotonically increasing marketing versions, so `1.0.0` is rejected with "You've already submitted this version".
- `5.0.0` is the natural next major, clearly marking the Vultisig rebrand.

## Test plan
- [ ] Merge, then run `eas build -p ios --profile production` from `main`
- [ ] Submit via `EXPO_APPLE_ID=... EXPO_APPLE_APP_SPECIFIC_PASSWORD=... npx eas submit -p ios --latest`
- [ ] Confirm build `5.0.0 (1)` appears on TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)