### PR TITLE
chore(ios): preserve keychain access across Team ID change (BLOCKED)

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,7 +32,11 @@
         "ITSAppUsesNonExemptEncryption": false
       },
       "entitlements": {
-        "aps-environment": "production"
+        "aps-environment": "production",
+        "keychain-access-groups": [
+          "$(AppIdentifierPrefix)money.terra.station",
+          "U5D98K4YPD.money.terra.station"
+        ]
       },
       "associatedDomains": [
         "applinks:station.app.link",


### PR DESCRIPTION
## ⚠️ DRAFT — BLOCKED on Apple Developer Portal config

**Do NOT merge until the Apple-side steps below are complete**, or the next iOS build will fail code signing.

## Context
Apple's 5.0.0 (1) TestFlight processing returned **ITMS-90076: Potential Loss of Keychain Access**:

> The previous version of software has an application-identifier value of `['U5D98K4YPD.money.terra.station']` and the new version of software being submitted has an application-identifier of `['5BP27CHH4Y.money.terra.station']`. This will result in a loss of keychain access.

Bundle ID (`money.terra.station`) is unchanged — it's the **Team ID prefix** that flipped during the Station Wallet → Vultisig App Transfer. On iOS, keychain items are scoped by the full application-identifier (`<TeamID>.<BundleID>`), so without mitigation every existing Station Wallet user who updates to the Vultisig build **loses access to their stored wallet data**.

## What this PR does
Adds `keychain-access-groups` entitlement declaring both the current team's group and the legacy `U5D98K4YPD.money.terra.station` group, so the migrated app can read keychain items written by the prior app.

## What's required on the Apple side FIRST
An **ASC Admin** (or whoever holds the Apple Developer Account Holder role on Vulti Holdings Limited) must:

1. **Verify the App Transfer was completed formally** via ASC → Apps → Station Wallet → App Information → Transfer App. If the app was just re-registered under a new team (not transferred), Apple won't grant the entitlement and we need a Developer Support case.
2. **Apple Developer Portal → Identifiers → `money.terra.station`**: confirm the "Previous Application Identifier" field shows `U5D98K4YPD.money.terra.station` (auto-populated after a successful transfer).
3. **Regenerate the iOS Distribution provisioning profile** — the new profile will include the `previous-application-identifiers` entitlement that authorizes the access group declared in this PR.
4. **Pull the new profile into EAS**: run `npx eas credentials -p ios` → Production → "Update provisioning profile".

Only after all four steps should this PR be marked Ready for Review and merged.

## Test plan after merge
- [ ] `eas build -p ios --profile production` succeeds (code signing would fail if Apple-side steps aren't done)
- [ ] Resubmit to TestFlight — ITMS-90076 should no longer appear
- [ ] Install a historical Station Wallet build on a test device, create a wallet, then update to the new Vultisig build and confirm the wallet is still accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)