### PR TITLE
chore(ios): add NSBluetoothAlwaysUsageDescription purpose string

### DIFF
--- a/app.json
+++ b/app.json
@@ -29,7 +29,8 @@
       "appleTeamId": "4268K8DFX6",
       "buildNumber": "1",
       "infoPlist": {
-        "ITSAppUsesNonExemptEncryption": false
+        "ITSAppUsesNonExemptEncryption": false,
+        "NSBluetoothAlwaysUsageDescription": "Vultisig uses Bluetooth to connect to supported hardware wallets (such as Ledger) for secure transaction signing."
       },
       "entitlements": {
         "aps-environment": "production"


### PR DESCRIPTION
## Summary
Fixes **ITMS-90683: Missing purpose string in Info.plist** from Apple's processing of TestFlight build 5.0.0 (1).

The binary links CoreBluetooth via `@ledgerhq/react-native-hw-transport-ble` (Ledger hardware-wallet pairing). Apple requires a user-facing purpose string for every privacy-sensitive API the binary references, whether or not the code path is exercised at runtime.

## What's added
\`\`\`json
"NSBluetoothAlwaysUsageDescription": "Vultisig uses Bluetooth to connect to supported hardware wallets (such as Ledger) for secure transaction signing."
\`\`\`

Only the modern key is added — `NSBluetoothAlwaysUsageDescription` covers iOS 13+. The legacy `NSBluetoothPeripheralUsageDescription` (iOS 12 and earlier) is not required; Apple will only show the modern string.

## Test plan
- [ ] Merge, rebuild production, resubmit to TestFlight
- [ ] Confirm ITMS-90683 no longer appears in Apple's processing email
- [ ] When a user first triggers Ledger pairing, iOS displays the permission prompt with the new purpose string

🤖 Generated with [Claude Code](https://claude.com/claude-code)