### PR TITLE
chore(deps): security overrides + remove unused @walletconnect/client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "@terra.kitchen/utils": "^1.0.7",
         "@vultisig/mpc-native": "^0.1.3",
         "@vultisig/walletcore-native": "^0.1.2",
-        "@walletconnect/client": "^1.6.5",
         "bech32": "^2.0.0",
         "bignumber.js": "^9.0.1",
         "bip39": "^3.1.0",
@@ -4428,12 +4427,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "license": "MIT"
-    },
     "node_modules/@types/luxon": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.4.0.tgz",
@@ -4950,279 +4943,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@walletconnect/browser-utils": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.8.0.tgz",
-      "integrity": "sha512-Wcqqx+wjxIo9fv6eBUFHPsW1y/bGWWRboni5dfD8PtOmrihrEpOCmvRJe4rfl7xgJW8Ea9UqKEaq0bIRLHlK4A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@walletconnect/safe-json": "1.0.0",
-        "@walletconnect/types": "^1.8.0",
-        "@walletconnect/window-getters": "1.0.0",
-        "@walletconnect/window-metadata": "1.0.0",
-        "detect-browser": "5.2.0"
-      }
-    },
-    "node_modules/@walletconnect/client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.8.0.tgz",
-      "integrity": "sha512-svyBQ14NHx6Cs2j4TpkQaBI/2AF4+LXz64FojTjMtV4VMMhl81jSO1vNeg+yYhQzvjcGH/GpSwixjyCW0xFBOQ==",
-      "deprecated": "WalletConnect's v1 SDKs are now deprecated. Please upgrade to a v2 SDK. For details see: https://docs.walletconnect.com/",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@walletconnect/core": "^1.8.0",
-        "@walletconnect/iso-crypto": "^1.8.0",
-        "@walletconnect/types": "^1.8.0",
-        "@walletconnect/utils": "^1.8.0"
-      }
-    },
-    "node_modules/@walletconnect/core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.8.0.tgz",
-      "integrity": "sha512-aFTHvEEbXcZ8XdWBw6rpQDte41Rxwnuk3SgTD8/iKGSRTni50gI9S3YEzMj05jozSiOBxQci4pJDMVhIUMtarw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@walletconnect/socket-transport": "^1.8.0",
-        "@walletconnect/types": "^1.8.0",
-        "@walletconnect/utils": "^1.8.0"
-      }
-    },
-    "node_modules/@walletconnect/crypto": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/crypto/-/crypto-1.1.0.tgz",
-      "integrity": "sha512-yZO8BBTQt7BcaemjDgwN56OmSv0OO4QjIpvtfj5OxZfL6IQZQWHOhwC6pJg+BmZPbDlJlWFqFuCZRtiPwRmsoA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/ciphers": "1.2.0",
-        "@noble/hashes": "1.7.0",
-        "@walletconnect/encoding": "^1.0.2",
-        "@walletconnect/environment": "^1.0.1",
-        "@walletconnect/randombytes": "^1.0.3",
-        "tslib": "1.14.1"
-      }
-    },
-    "node_modules/@walletconnect/crypto/node_modules/@noble/ciphers": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.2.0.tgz",
-      "integrity": "sha512-YGdEUzYEd+82jeaVbSKKVp1jFZb8LwaNMIIzHFkihGvYdd/KKAr7KaJHdEdSYGredE3ssSravXIa0Jxg28Sv5w==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@walletconnect/crypto/node_modules/@noble/hashes": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
-      "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@walletconnect/crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
-    "node_modules/@walletconnect/encoding": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/encoding/-/encoding-1.0.2.tgz",
-      "integrity": "sha512-CrwSBrjqJ7rpGQcTL3kU+Ief+Bcuu9PH6JLOb+wM6NITX1GTxR/MfNwnQfhLKK6xpRAyj2/nM04OOH6wS8Imag==",
-      "license": "MIT",
-      "dependencies": {
-        "is-typedarray": "1.0.0",
-        "tslib": "1.14.1",
-        "typedarray-to-buffer": "3.1.5"
-      }
-    },
-    "node_modules/@walletconnect/encoding/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
-    "node_modules/@walletconnect/environment": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.1.tgz",
-      "integrity": "sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "1.14.1"
-      }
-    },
-    "node_modules/@walletconnect/environment/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
-    "node_modules/@walletconnect/iso-crypto": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.8.0.tgz",
-      "integrity": "sha512-pWy19KCyitpfXb70hA73r9FcvklS+FvO9QUIttp3c2mfW8frxgYeRXfxLRCIQTkaYueRKvdqPjbyhPLam508XQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@walletconnect/crypto": "^1.0.2",
-        "@walletconnect/types": "^1.8.0",
-        "@walletconnect/utils": "^1.8.0"
-      }
-    },
-    "node_modules/@walletconnect/jsonrpc-types": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.4.tgz",
-      "integrity": "sha512-P6679fG/M+wuWg9TY8mh6xFSdYnFyFjwFelxyISxMDrlbXokorEVXYOxiqEbrU3x1BmBoCAJJ+vtEaEoMlpCBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "events": "^3.3.0",
-        "keyvaluestorage-interface": "^1.0.0"
-      }
-    },
-    "node_modules/@walletconnect/jsonrpc-utils": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
-      "integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
-      "license": "MIT",
-      "dependencies": {
-        "@walletconnect/environment": "^1.0.1",
-        "@walletconnect/jsonrpc-types": "^1.0.3",
-        "tslib": "1.14.1"
-      }
-    },
-    "node_modules/@walletconnect/jsonrpc-utils/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
-    "node_modules/@walletconnect/randombytes": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/randombytes/-/randombytes-1.1.0.tgz",
-      "integrity": "sha512-X+LO/9ClnXX2Q/1+u83qMnohVaxC4qsXByM/gMSwGMrUObxEiqEWS+b9Upg9oNl6mTr85dTCRF8W17KVcKKXQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.7.0",
-        "@walletconnect/encoding": "^1.0.2",
-        "@walletconnect/environment": "^1.0.1",
-        "tslib": "1.14.1"
-      }
-    },
-    "node_modules/@walletconnect/randombytes/node_modules/@noble/hashes": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
-      "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@walletconnect/randombytes/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
-    "node_modules/@walletconnect/safe-json": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.0.tgz",
-      "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg==",
-      "license": "MIT"
-    },
-    "node_modules/@walletconnect/socket-transport": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.8.0.tgz",
-      "integrity": "sha512-5DyIyWrzHXTcVp0Vd93zJ5XMW61iDM6bcWT4p8DTRfFsOtW46JquruMhxOLeCOieM4D73kcr3U7WtyR4JUsGuQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@walletconnect/types": "^1.8.0",
-        "@walletconnect/utils": "^1.8.0",
-        "ws": "7.5.3"
-      }
-    },
-    "node_modules/@walletconnect/socket-transport/node_modules/ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@walletconnect/types": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.8.0.tgz",
-      "integrity": "sha512-Cn+3I0V0vT9ghMuzh1KzZvCkiAxTq+1TR2eSqw5E5AVWfmCtECFkVZBP6uUJZ8YjwLqXheI+rnjqPy7sVM4Fyg==",
-      "deprecated": "WalletConnect's v1 SDKs are now deprecated. Please upgrade to a v2 SDK. For details see: https://docs.walletconnect.com/",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@walletconnect/utils": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.8.0.tgz",
-      "integrity": "sha512-zExzp8Mj1YiAIBfKNm5u622oNw44WOESzo6hj+Q3apSMIb0Jph9X3GDIdbZmvVZsNPxWDL7uodKgZcCInZv2vA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@walletconnect/browser-utils": "^1.8.0",
-        "@walletconnect/encoding": "^1.0.1",
-        "@walletconnect/jsonrpc-utils": "^1.0.3",
-        "@walletconnect/types": "^1.8.0",
-        "bn.js": "4.11.8",
-        "js-sha3": "0.8.0",
-        "query-string": "6.13.5"
-      }
-    },
-    "node_modules/@walletconnect/utils/node_modules/query-string": {
-      "version": "6.13.5",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.5.tgz",
-      "integrity": "sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "decode-uri-component": "^0.2.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@walletconnect/window-getters": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.0.tgz",
-      "integrity": "sha512-xB0SQsLaleIYIkSsl43vm8EwETpBzJ2gnzk7e0wMF3ktqiTGS6TFHxcprMl5R44KKh4tCcHCJwolMCaDSwtAaA==",
-      "license": "MIT"
-    },
-    "node_modules/@walletconnect/window-metadata": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.0.tgz",
-      "integrity": "sha512-9eFvmJxIKCC3YWOL97SgRkKhlyGXkrHwamfechmqszbypFspaSk+t2jQXAEU7YClHF6Qjw5eYOmy1//zFi9/GA==",
-      "license": "MIT",
-      "dependencies": {
-        "@walletconnect/window-getters": "^1.0.0"
-      }
-    },
     "node_modules/@wix-pilot/core": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/@wix-pilot/core/-/core-3.4.2.tgz",
@@ -5313,9 +5033,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -5678,13 +5398,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.31.0.tgz",
+      "integrity": "sha512-HGIUj/P74co3rSLBV9SHz9LMgCmrXFEtkfMcC5r6bS5j3dBHUcAje2tS4fmU6WM20kuhvUX04XE58594dpgi1g==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -6132,9 +5853,9 @@
       "license": "MIT"
     },
     "node_modules/bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
     "node_modules/boolbase": {
@@ -7297,12 +7018,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/detect-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
-      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA==",
-      "license": "MIT"
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -7796,12 +7511,6 @@
         "minimalistic-assert": "^1.0.1",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "license": "MIT"
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -9349,9 +9058,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -10645,12 +10354,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "license": "MIT"
-    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -11850,12 +11553,6 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
-    },
-    "node_modules/keyvaluestorage-interface": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
-      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==",
-      "license": "MIT"
     },
     "node_modules/klaw-sync": {
       "version": "6.0.0",
@@ -14297,9 +13994,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "6.11.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
-      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -14313,13 +14010,11 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
       },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/protobufjs/node_modules/@types/node": {
@@ -14330,6 +14025,18 @@
       "dependencies": {
         "undici-types": "~7.18.0"
       }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -17128,15 +16835,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "license": "MIT",
-      "dependencies": {
-        "is-typedarray": "^1.0.0"
       }
     },
     "node_modules/typeforce": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@terra.kitchen/utils": "^1.0.7",
     "@vultisig/mpc-native": "^0.1.3",
     "@vultisig/walletcore-native": "^0.1.2",
-    "@walletconnect/client": "^1.6.5",
     "bech32": "^2.0.0",
     "bignumber.js": "^9.0.1",
     "bip39": "^3.1.0",
@@ -94,7 +93,12 @@
     "stream-browserify": "^3.0.0"
   },
   "overrides": {
-    "expo-build-properties": "~55.0.13"
+    "expo-build-properties": "~55.0.13",
+    "protobufjs": "^7.5.5",
+    "axios": "^0.31.0",
+    "follow-redirects": "^1.16.0",
+    "@xmldom/xmldom": "^0.8.12",
+    "bn.js": "^4.12.3"
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",


### PR DESCRIPTION
## Summary

Address the bulk of our open Dependabot alerts by adding npm `overrides` to force vulnerable transitive deps to patched versions, and by removing `@walletconnect/client` — which is a direct dep that is no longer imported anywhere in `src/` (only stale image assets + an unused `walletconnectID` config field remain).

## Alerts closed by this PR

| # | Severity | Package | Why fixed here |
|---|----------|---------|----------------|
| [#68](https://github.com/StationWallet/station-mobile/security/dependabot/68) | critical | `protobufjs` | override → `^7.5.5` |
| [#67](https://github.com/StationWallet/station-mobile/security/dependabot/67) | medium   | `axios` | override → `^0.31.0` |
| [#66](https://github.com/StationWallet/station-mobile/security/dependabot/66) | medium   | `axios` | override → `^0.31.0` |
| [#65](https://github.com/StationWallet/station-mobile/security/dependabot/65) | medium   | `follow-redirects` | override → `^1.16.0` |
| [#59](https://github.com/StationWallet/station-mobile/security/dependabot/59) | high     | `axios` | override → `^0.31.0` |
| [#58](https://github.com/StationWallet/station-mobile/security/dependabot/58) | high     | `ws` | removing `@walletconnect/client` eliminates the only vulnerable copy (7.5.3); all remaining `ws` copies are already ≥ 7.5.10 |
| [#57](https://github.com/StationWallet/station-mobile/security/dependabot/57) | medium   | `axios` | override → `^0.31.0` |
| [#51](https://github.com/StationWallet/station-mobile/security/dependabot/51) | high     | `@xmldom/xmldom` | override → `^0.8.12` |
| [#40](https://github.com/StationWallet/station-mobile/security/dependabot/40) | medium   | `bn.js` | override → `^4.12.3` |
| [#34](https://github.com/StationWallet/station-mobile/security/dependabot/34) | high     | `axios` | override → `^0.31.0` |

## Alerts being dismissed (separately, in the UI) as not-applicable

Each of these has been code-audited; the vulnerable path is not exercised by this app.

| # | Severity | Package | Rationale |
|---|----------|---------|-----------|
| [#56](https://github.com/StationWallet/station-mobile/security/dependabot/56) | critical | `crypto-js` | CVE is about the default PBKDF2 iteration count (`1`). `src/utils/crypto.ts:15` sets `iterations: 100` explicitly, so the default-value CVE does not apply. (A separate, higher-effort migration is warranted to raise the iteration count closer to OWASP guidance, but that requires re-encrypting existing wallet data and is out of scope for a Dependabot sweep.) |
| [#61](https://github.com/StationWallet/station-mobile/security/dependabot/61) | high     | `lodash`   | `_.template` is not imported or used anywhere in `src/`. |
| [#60](https://github.com/StationWallet/station-mobile/security/dependabot/60) | medium   | `lodash`   | The only `_.omit` call in `src/` (`src/utils/authData.ts:71`) passes a string key, not an array path — the array-path prototype-pollution bypass is not reachable. |

## Alerts that remain open — no safe fix available

| # | Severity | Package | Why it stays |
|---|----------|---------|--------------|
| [#55](https://github.com/StationWallet/station-mobile/security/dependabot/55) | high | `d3-color` | `d3-interpolate@1.4.0` and `d3-scale@1.0.7` (pulled in by `react-native-svg-charts@5.4.0`) pin `d3-color: '1'`. Overriding to `^3.1.0` would break those at runtime. The ReDoS also requires attacker-controlled color strings, which we don't accept. Resolving this properly means replacing `react-native-svg-charts` with a maintained alternative — tracked separately. |
| [#25](https://github.com/StationWallet/station-mobile/security/dependabot/25) | low  | `elliptic` | No patched version published upstream. Reached only via `@terra-money/ledger-terra-js` → `secp256k1` for Ledger signing. |

## Test plan

- [x] `npm install` clean (lockfile rebuilt with overrides)
- [x] `npm run typecheck` passes
- [x] `npm test` — all 514 tests pass (the 4 failing suites are pre-existing failures inside `.claude/worktrees/…` that have nothing to do with this PR)
- [x] `npm run lint:check` passes
- [x] `npm ls` confirms overrides took effect: `protobufjs@7.5.5`, `axios@0.31.0`, `follow-redirects@1.16.0`, `@xmldom/xmldom@0.8.12`, `bn.js@4.12.3` deduped across the tree
- [ ] Smoke test on simulator before merge (dev+Testflight builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)