### PR TITLE
feat(auth): add Import Fast Vault entry from AuthMenu

### DIFF
--- a/src/navigation/MigrationNavigator.tsx
+++ b/src/navigation/MigrationNavigator.tsx
@@ -99,7 +99,11 @@ export type MigrationStackParams = {
 
 const Stack = createStackNavigator<MigrationStackParams>()
 
-type MigrationEntry = 'default' | 'create-vault' | 'recover-seed'
+type MigrationEntry =
+  | 'default'
+  | 'create-vault'
+  | 'recover-seed'
+  | 'import-vault'
 
 export default function MigrationNavigator({
   initialEntry = 'default',
@@ -110,6 +114,8 @@ export default function MigrationNavigator({
     initialEntry === 'create-vault' || initialEntry === 'recover-seed'
   const initialRouteName = isVaultNameEntry
     ? 'VaultName'
+    : initialEntry === 'import-vault'
+    ? 'ImportVault'
     : 'RiveIntro'
   const vaultNameInitialParams = isVaultNameEntry
     ? {

--- a/src/navigation/hooks.ts
+++ b/src/navigation/hooks.ts
@@ -3,8 +3,10 @@ import { createContext, useContext } from 'react'
 export interface WalletNav {
   onWalletDisconnected: () => void
   goToMigration?: () => void
+  goToAuth: () => void
   startCreateVault: () => void
   startSeedRecovery: () => void
+  startImportVault: () => void
   wallets: LocalWallet[]
   refreshWallets: () => Promise<void>
 }
@@ -12,8 +14,10 @@ export interface WalletNav {
 export const WalletNavContext = createContext<WalletNav>({
   onWalletDisconnected: (): void => {},
   goToMigration: undefined,
+  goToAuth: (): void => {},
   startCreateVault: (): void => {},
   startSeedRecovery: (): void => {},
+  startImportVault: (): void => {},
   wallets: [],
   refreshWallets: async (): Promise<void> => {},
 })

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -31,6 +31,7 @@ export type MigrationEntry =
   | 'default'
   | 'create-vault'
   | 'recover-seed'
+  | 'import-vault'
 
 export default function AppNavigator(): React.ReactElement | null {
   const [wallets, setWallets] = useState<LocalWallet[] | null>(null)
@@ -114,6 +115,16 @@ export default function AppNavigator(): React.ReactElement | null {
     setRootRoute('Migration')
   }, [])
 
+  const startImportVault = useCallback(() => {
+    setMigrationEntry('import-vault')
+    setRootRoute('Migration')
+  }, [])
+
+  const goToAuth = useCallback(() => {
+    setMigrationEntry('default')
+    setRootRoute('Auth')
+  }, [])
+
   const navTheme = useMemo(
     () => ({
       ...DefaultTheme,
@@ -130,16 +141,20 @@ export default function AppNavigator(): React.ReactElement | null {
     () => ({
       onWalletDisconnected,
       goToMigration,
+      goToAuth,
       startCreateVault,
       startSeedRecovery,
+      startImportVault,
       wallets,
       refreshWallets,
     }),
     [
       onWalletDisconnected,
       goToMigration,
+      goToAuth,
       startCreateVault,
       startSeedRecovery,
+      startImportVault,
       wallets,
       refreshWallets,
     ]

--- a/src/screens/auth/AuthMenu.tsx
+++ b/src/screens/auth/AuthMenu.tsx
@@ -18,7 +18,8 @@ const AuthMenu = ({
 }: {
   navigation: { navigate: (screen: string) => void }
 }): React.ReactElement => {
-  const { goToMigration, startCreateVault } = useWalletNav()
+  const { goToMigration, startCreateVault, startImportVault } =
+    useWalletNav()
   const insets = useSafeAreaInsets()
 
   return (
@@ -67,6 +68,16 @@ const AuthMenu = ({
           >
             <Text style={styles.secondaryButtonText}>
               Recover Wallet
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            testID="auth-import-fast-vault"
+            style={styles.secondaryButton}
+            onPress={startImportVault}
+          >
+            <Text style={styles.secondaryButtonText}>
+              Import Fast Vault
             </Text>
           </TouchableOpacity>
 

--- a/src/screens/migration/ImportVault.tsx
+++ b/src/screens/migration/ImportVault.tsx
@@ -15,6 +15,7 @@ import FileDropZone from 'components/migration/FileDropZone'
 import DecryptPasswordSheet from 'components/migration/DecryptPasswordSheet'
 import { useImportFlow } from 'hooks/useImportFlow'
 import { MIGRATION } from 'consts/migration'
+import { useWalletNav } from 'navigation/hooks'
 
 function BackChevron(): React.ReactElement {
   return (
@@ -84,7 +85,16 @@ function ImportTooltip({
 
 export default function ImportVault(): React.ReactElement {
   const navigation = useNavigation()
+  const { goToAuth } = useWalletNav()
   const [showTooltip, setShowTooltip] = useState(false)
+
+  const handleBack = (): void => {
+    if (navigation.canGoBack()) {
+      navigation.goBack()
+    } else {
+      goToAuth()
+    }
+  }
   const {
     loading,
     fileName,
@@ -107,10 +117,7 @@ export default function ImportVault(): React.ReactElement {
   return (
     <View style={styles.container}>
       <View style={[styles.toolbar, { paddingTop: insets.top + 8 }]}>
-        <GlassButton
-          onPress={() => navigation.goBack()}
-          testID="import-vault-back"
-        >
+        <GlassButton onPress={handleBack} testID="import-vault-back">
           <BackChevron />
         </GlassButton>
         <Text fontType="brockmann-medium" style={styles.toolbarTitle}>

--- a/src/screens/migration/VaultName.tsx
+++ b/src/screens/migration/VaultName.tsx
@@ -23,6 +23,7 @@ import MigrationToolbar from 'components/migration/MigrationToolbar'
 import { formStyles } from 'components/migration/migrationStyles'
 import { MIGRATION } from 'consts/migration'
 import type { MigrationStackParams } from 'navigation/MigrationNavigator'
+import { useWalletNav } from 'navigation/hooks'
 
 type Nav = StackNavigationProp<MigrationStackParams, 'VaultName'>
 type Route = RouteProp<MigrationStackParams, 'VaultName'>
@@ -30,9 +31,18 @@ type Route = RouteProp<MigrationStackParams, 'VaultName'>
 export default function VaultName(): React.ReactElement {
   const navigation = useNavigation<Nav>()
   const route = useRoute<Route>()
+  const { goToAuth } = useWalletNav()
   const mode = route.params?.mode ?? 'create'
   const insets = useSafeAreaInsets()
   const [name, setName] = useState('')
+
+  const handleBack = (): void => {
+    if (navigation.canGoBack()) {
+      navigation.goBack()
+    } else {
+      goToAuth()
+    }
+  }
 
   return (
     <View style={formStyles.container}>
@@ -41,7 +51,7 @@ export default function VaultName(): React.ReactElement {
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       >
         <View style={{ paddingTop: insets.top }}>
-          <MigrationToolbar onBack={() => navigation.goBack()} />
+          <MigrationToolbar onBack={handleBack} />
         </View>
 
         <StepProgressBar currentStep={1} />


### PR DESCRIPTION
## Summary
- Adds an **Import Fast Vault** button to `AuthMenu` that deep-links to the existing `ImportVault` flow (same flow reached via `MigrationHome` → "I already have a Fast Vault")
- Plumbed through a new `'import-vault'` `MigrationEntry` + `startImportVault` callback on `WalletNav` so `MigrationNavigator` opens directly on `ImportVault`
- Fixes a dead-end **back button** on `ImportVault` and `VaultName` when they're entered as the initial route of `MigrationNavigator` via any `AuthMenu` deep-link. Both now check `navigation.canGoBack()` and fall back to a new `goToAuth()` callback that switches the root navigator back to `Auth`. Production flow via `MigrationHome` is unchanged (history exists, so `goBack()` still wins).

## Files touched
- `src/navigation/hooks.ts` — added `startImportVault`, `goToAuth` on `WalletNav`
- `src/navigation/index.tsx` — `'import-vault'` entry + callback
- `src/navigation/MigrationNavigator.tsx` — routes `'import-vault'` to `ImportVault` as initial screen
- `src/screens/auth/AuthMenu.tsx` — new button (testID `auth-import-fast-vault`)
- `src/screens/migration/ImportVault.tsx`, `src/screens/migration/VaultName.tsx` — `canGoBack()` fallback to `goToAuth()`

## Test plan
- [ ] `AuthMenu` → tap **Import Fast Vault** → lands directly on `ImportVault`
- [ ] From that `ImportVault`, tap back chevron → returns to `AuthMenu`
- [ ] `AuthMenu` → tap **Create New Wallet** (dev path) → lands on `VaultName` → tap back → returns to `AuthMenu`
- [ ] `MigrationHome` → **I already have a Fast Vault** → `ImportVault` → tap back → still returns to `MigrationHome` (unchanged)
- [ ] `MigrationHome` → Start Migration → `VaultName` → tap back → still returns to previous screen (unchanged)
- [ ] `npm run typecheck` passes
- [ ] `npm run lint:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)