### PR TITLE
fix(eas): link build profiles to EAS environments

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -8,16 +8,19 @@
       "developmentClient": true,
       "distribution": "internal",
       "channel": "development",
+      "environment": "development",
       "ios": {
         "simulator": true
       }
     },
     "preview": {
       "distribution": "internal",
-      "channel": "preview"
+      "channel": "preview",
+      "environment": "preview"
     },
     "production": {
       "channel": "production",
+      "environment": "production",
       "node": "20.20.2"
     }
   },


### PR DESCRIPTION
## Summary
- Add explicit `environment` field to each build profile in `eas.json` so env vars scoped to an EAS environment (Production/Preview/Development) are actually injected into the build container.
- Without this, `GITHUB_PACKAGES_TOKEN` (stored in the Production environment) is not available to Gradle, causing wallet-core resolution to fail with 401 Unauthorized.

## Why
Per [Expo docs](https://docs.expo.dev/eas/environment-variables/), build profiles do not auto-map to environments by name — the `environment` field must be declared explicitly. Profile name and environment name coincide here by convention only.

## Test plan
- [ ] Kick off `eas build --profile production --platform android`
- [ ] Confirm the build log shows `GITHUB_PACKAGES_TOKEN` injected
- [ ] Confirm Gradle resolves `com.trustwallet:wallet-core` without 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)