### PR TITLE
fix(android): pass GitHub Packages PAT as Gradle project property

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -21,7 +21,10 @@
     "production": {
       "channel": "production",
       "environment": "production",
-      "node": "20.20.2"
+      "node": "20.20.2",
+      "android": {
+        "gradleCommand": ":app:bundleRelease -Pgpr.key=$GITHUB_PACKAGES_TOKEN"
+      }
     }
   },
   "submit": {

--- a/plugins/withTrustwalletMavenRepo.js
+++ b/plugins/withTrustwalletMavenRepo.js
@@ -13,21 +13,27 @@ const {
  * repositories, not the declaring submodule's — so the repo MUST live at
  * the app level even though the dependency originates from a subproject.
  *
- * The PAT is read from `GITHUB_PACKAGES_TOKEN` at prebuild time (Node side)
- * and baked literally into the generated Groovy. We used to defer the
- * lookup to Gradle via `System.getenv(...)`, but observed 401s on EAS
- * Build even with the env var present in the build environment — Gradle
- * JVM didn't pick it up. Baking at prebuild is robust because Node's
- * `process.env` reliably sees the EAS-injected variable.
+ * Credentials are resolved at Gradle-run time in this order (GitHub's
+ * documented pattern for the Gradle registry):
  *
- * `android/` is gitignored and Expo prebuild regenerates it on every run,
- * so the baked PAT only lives in the ephemeral build VM — never in git.
+ *   1. Project property `gpr.key` — passed on the Gradle command line
+ *      via `-Pgpr.key=...` (see `eas.json` → `android.gradleCommand`).
+ *      On EAS Build this is populated from the `GITHUB_PACKAGES_TOKEN`
+ *      environment variable, which sidesteps a known EAS bug where
+ *      build-env vars don't propagate to the Gradle JVM
+ *      (expo/eas-cli#1858).
+ *   2. Environment variable `GITHUB_PACKAGES_TOKEN` — fallback for local
+ *      development where the shell exports the token directly and the
+ *      JVM inherits it as expected.
+ *
+ * For local work you can alternately put the token in
+ * `~/.gradle/gradle.properties`:
+ *     gpr.key=ghp_xxx...
  *
  *   - GITHUB_PACKAGES_TOKEN = classic PAT with `read:packages` scope.
  *     Generate one at https://github.com/settings/tokens/new (classic
  *     tokens only — fine-grained tokens are not supported by the
- *     GitHub Packages Maven registry yet). Export it in your shell rc:
- *       export GITHUB_PACKAGES_TOKEN=ghp_xxx...
+ *     GitHub Packages Maven registry yet).
  *
  * GitHub Packages' Basic Auth requires a non-empty `username`, but the
  * value is not validated against the token — any literal works — so we
@@ -36,32 +42,17 @@ const {
 const MARKER =
   '// trustwallet-maven-repo (managed by withTrustwalletMavenRepo)'
 
-function escapeGroovyString(value) {
-  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
-}
-
-function buildRepoBlock() {
-  const token = process.env.GITHUB_PACKAGES_TOKEN || ''
-  if (!token) {
-    throw new Error(
-      '[withTrustwalletMavenRepo] GITHUB_PACKAGES_TOKEN is not set — ' +
-        'Gradle will 401 against maven.pkg.github.com/trustwallet. ' +
-        'Export a classic PAT with read:packages scope.'
-    )
-  }
-  const safeToken = escapeGroovyString(token)
-  return [
-    `    ${MARKER}`,
-    '    maven {',
-    '      url = uri("https://maven.pkg.github.com/trustwallet/wallet-core")',
-    '      credentials {',
-    '        username = "token"',
-    `        password = "${safeToken}"`,
-    '      }',
-    '      content { includeGroup("com.trustwallet") }',
-    '    }',
-  ].join('\n')
-}
+const REPO_BLOCK = [
+  `    ${MARKER}`,
+  '    maven {',
+  '      url = uri("https://maven.pkg.github.com/trustwallet/wallet-core")',
+  '      credentials {',
+  '        username = "token"',
+  '        password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_PACKAGES_TOKEN") ?: ""',
+  '      }',
+  '      content { includeGroup("com.trustwallet") }',
+  '    }',
+].join('\n')
 
 /**
  * Find the matching `}` for the `{` at `openIndex`, handling nested braces
@@ -134,7 +125,7 @@ const withTrustwalletMavenRepo = (config) =>
 
     const before = contents.slice(0, closeBraceIdx)
     const after = contents.slice(closeBraceIdx)
-    modConfig.modResults.contents = `${before}${buildRepoBlock()}\n  ${after}`
+    modConfig.modResults.contents = `${before}${REPO_BLOCK}\n  ${after}`
 
     return modConfig
   })


### PR DESCRIPTION
## Summary
- Replace the prebuild-bake approach (PR #56) with the canonical GitHub-documented pattern: emit `project.findProperty(\"gpr.key\")` in the generated Groovy and pass the PAT on the Gradle command line via `-Pgpr.key=\$GITHUB_PACKAGES_TOKEN` in `eas.json`.
- EAS expands `\$VAR` in `gradleCommand` from the build environment, so Gradle receives the token as a first-class project property — no env-var inheritance through the JVM, no literal token materialised in any generated file.
- Retain `System.getenv(\"GITHUB_PACKAGES_TOKEN\")` fallback for local dev ergonomics.

## Why
PR #56 worked but wrote the PAT literally into the generated `android/build.gradle` on the ephemeral EAS VM. Project properties avoid that disk-surface entirely.

It also sidesteps [expo/eas-cli#1858](https://github.com/expo/eas-cli/issues/1858), the documented EAS bug where env vars present in the build shell don't propagate into the Gradle JVM's `System.getenv()` — which is the actual root cause of the 401s we were working around.

This is the pattern [GitHub's own Gradle-registry docs](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry) recommend.

## Test plan
- [ ] `eas build --profile production --platform android` succeeds
- [ ] Gradle resolves `com.trustwallet:wallet-core-proto:4.3.22` without 401
- [ ] Local `npm run android` still works (env-var fallback path)

## Follow-up
`preview`/`development` build profiles currently rely on the env-var fallback and would hit the same EAS JVM-propagation bug if a non-prod Android build is ever run. Low priority — production is unblocked now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)