### PR TITLE
chore(android): bump versionCode to 50000001

### DIFF
--- a/app.json
+++ b/app.json
@@ -42,7 +42,7 @@
         "backgroundColor": "#1f42b4"
       },
       "package": "money.terra.station",
-      "versionCode": 1,
+      "versionCode": 50000001,
 
       "permissions": [
         "android.permission.CAMERA",


### PR DESCRIPTION
## Summary
- Bump Android \`versionCode\` in \`app.json\` from \`1\` to \`50000001\` so the next EAS build can be uploaded to the Play Console.

## Why
Play Console rejects uploads whose \`versionCode\` does not strictly exceed every previously uploaded bundle. The historical max on this Play listing is \`20000002\` (2.0.0 release from 2022), so the prior value of \`1\` was rejected as a duplicate.

\`50000001\` follows the existing encoding scheme — MAJOR × 1e7 + MINOR × 1e5 + PATCH × 1e3 + BUILD — keeping the \`versionCode\` in sync with the user-facing \`"version": "5.0.0"\`.

## Follow-up (optional)
To stop manually bumping this, set \`"appVersionSource": "remote"\` in \`eas.json\` and \`"autoIncrement": true\` on the production profile — EAS then tracks and auto-increments the versionCode per build.

## Test plan
- [ ] \`eas build --profile production --platform android\` produces an .aab with versionCode 50000001
- [ ] Play Console accepts the upload (no "version code already used" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)