### PR TITLE
chore(eas): auto-increment versionCode on EAS without fingerprint drift

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 15.0.0",
-    "appVersionSource": "local"
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {
@@ -22,6 +22,7 @@
       "channel": "production",
       "environment": "production",
       "node": "20.20.2",
+      "autoIncrement": true,
       "android": {
         "gradleCommand": ":app:bundleRelease -Pgpr.key=$GITHUB_PACKAGES_TOKEN"
       }

--- a/fingerprint.config.js
+++ b/fingerprint.config.js
@@ -1,0 +1,16 @@
+/**
+ * Exclude `version`, `android.versionCode`, and `ios.buildNumber` from the
+ * fingerprint hash so bumping the app version does not invalidate the
+ * runtime-version fingerprint.
+ *
+ * This pairs with `"appVersionSource": "remote"` + `"autoIncrement": true`
+ * in eas.json: EAS can safely auto-bump versionCode/buildNumber without
+ * causing a "Runtime version calculated on local machine / on EAS" mismatch
+ * in expo-updates.
+ *
+ * See expo/expo#28712 — the `ExpoConfigVersions` skip was added precisely
+ * to unblock this workflow.
+ */
+module.exports = {
+  sourceSkips: ['ExpoConfigVersions'],
+}


### PR DESCRIPTION
## Summary
- Re-enable EAS-side auto-incrementing of Android \`versionCode\` / iOS \`buildNumber\` so humans no longer have to bump \`app.json\` per release.
- Add \`fingerprint.config.js\` with \`sourceSkips: ['ExpoConfigVersions']\` so version bumps no longer change the fingerprint — the root conflict that blocked the earlier attempt (reverted in commit 3303437).
- Switch \`cli.appVersionSource\` to \`remote\` so EAS owns versionCode/buildNumber; \`app.json\` values become a one-time seed.

## Why
Previous attempt (commit 3303437) was reverted because \`autoIncrement\` conflicted with \`"runtimeVersion": { "policy": "fingerprint" }\` — bumping versionCode changed the fingerprint hash and surfaced as "Runtime version calculated on local machine / on EAS" mismatch in expo-updates. The \`@expo/fingerprint\` team shipped \`SourceSkips.ExpoConfigVersions\` ([expo/expo#28712](https://github.com/expo/expo/pull/28712)) specifically to unblock this workflow — skipping version fields from the hash so EAS is free to bump them.

## ⚠️ Required post-merge action (one-time)
Before kicking off the next production build, run:
\`\`\`
eas build:version:sync
\`\`\`
This seeds EAS with the current \`versionCode\` (50000001) / \`buildNumber\` from \`app.json\`. After that, future \`eas build --profile production\` runs auto-bump.

## Test plan
- [ ] Run \`eas build:version:sync\` locally
- [ ] Kick off \`eas build --profile production --platform android\` — no fingerprint mismatch error
- [ ] Confirm produced .aab has versionCode 50000002 (or whatever the auto-bump lands on)
- [ ] Play Console accepts the new upload

## Sources
- [Expo docs — App versions](https://docs.expo.dev/build-reference/app-versions/)
- [Expo docs — Fingerprint sourceSkips](https://docs.expo.dev/versions/latest/sdk/fingerprint/)
- [expo/expo#28712 — add ExpoConfigVersions skip](https://github.com/expo/expo/pull/28712)

🤖 Generated with [Claude Code](https://claude.com/claude-code)