### PR TITLE
fix(navigation): RecoverSeed next button was a no-op

### DIFF
--- a/src/navigation/MigrationNavigator.tsx
+++ b/src/navigation/MigrationNavigator.tsx
@@ -104,7 +104,6 @@ const Stack = createStackNavigator<MigrationStackParams>()
 type MigrationEntry =
   | 'default'
   | 'create-vault'
-  | 'recover-seed'
   | 'recover-seed-input'
   | 'import-vault'
 
@@ -113,23 +112,18 @@ export default function MigrationNavigator({
 }: {
   initialEntry?: MigrationEntry
 }): React.ReactElement {
-  const isVaultNameEntry =
-    initialEntry === 'create-vault' || initialEntry === 'recover-seed'
-  const initialRouteName = isVaultNameEntry
-    ? 'VaultName'
-    : initialEntry === 'import-vault'
-    ? 'ImportVault'
-    : initialEntry === 'recover-seed-input'
-    ? 'RecoverSeed'
-    : 'RiveIntro'
-  const vaultNameInitialParams = isVaultNameEntry
-    ? {
-        mode:
-          initialEntry === 'recover-seed'
-            ? ('recover-seed' as const)
-            : ('create' as const),
-      }
-    : undefined
+  const initialRouteName =
+    initialEntry === 'create-vault'
+      ? 'VaultName'
+      : initialEntry === 'import-vault'
+      ? 'ImportVault'
+      : initialEntry === 'recover-seed-input'
+      ? 'RecoverSeed'
+      : 'RiveIntro'
+  const vaultNameInitialParams =
+    initialEntry === 'create-vault'
+      ? { mode: 'create' as const }
+      : undefined
 
   return (
     <Stack.Navigator

--- a/src/navigation/hooks.ts
+++ b/src/navigation/hooks.ts
@@ -7,13 +7,9 @@ export interface WalletNav {
   goHome: () => void
   startCreateVault: () => void
   /**
-   * Seed already written to RecoverWalletStore. Routes straight to VaultName
-   * in recover-seed mode (continues keygen).
-   */
-  startSeedRecovery: () => void
-  /**
-   * User still needs to enter a seed. Routes to RecoverSeed, which captures
-   * the seed into RecoverWalletStore then calls startSeedRecovery.
+   * Routes to RecoverSeed, which captures the user's seed into
+   * RecoverWalletStore then advances into the vault creation flow in
+   * recover-seed mode.
    */
   startSeedRecoveryInput: () => void
   startImportVault: () => void
@@ -27,7 +23,6 @@ export const WalletNavContext = createContext<WalletNav>({
   goToAuth: (): void => {},
   goHome: (): void => {},
   startCreateVault: (): void => {},
-  startSeedRecovery: (): void => {},
   startSeedRecoveryInput: (): void => {},
   startImportVault: (): void => {},
   wallets: [],

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -31,7 +31,6 @@ type RootRoute = 'Migration' | 'Auth' | 'Main'
 export type MigrationEntry =
   | 'default'
   | 'create-vault'
-  | 'recover-seed'
   | 'recover-seed-input'
   | 'import-vault'
 
@@ -125,18 +124,9 @@ export default function AppNavigator(): React.ReactElement | null {
   }, [])
 
   /**
-   * Seed already written to RecoverWalletStore. Routes straight to VaultName
-   * in recover-seed mode (continues keygen).
-   */
-  const startSeedRecovery = useCallback(() => {
-    preMigrationRootRef.current = rootRouteRef.current
-    setMigrationEntry('recover-seed')
-    setRootRoute('Migration')
-  }, [])
-
-  /**
-   * User still needs to enter a seed. Routes to RecoverSeed, which captures
-   * the seed into RecoverWalletStore then calls startSeedRecovery.
+   * Routes to RecoverSeed, which captures the user's seed into
+   * RecoverWalletStore then navigates within the Migration stack to VaultName
+   * in recover-seed mode.
    */
   const startSeedRecoveryInput = useCallback(() => {
     preMigrationRootRef.current = rootRouteRef.current
@@ -191,7 +181,6 @@ export default function AppNavigator(): React.ReactElement | null {
       goToAuth,
       goHome,
       startCreateVault,
-      startSeedRecovery,
       startSeedRecoveryInput,
       startImportVault,
       wallets,
@@ -203,7 +192,6 @@ export default function AppNavigator(): React.ReactElement | null {
       goToAuth,
       goHome,
       startCreateVault,
-      startSeedRecovery,
       startSeedRecoveryInput,
       startImportVault,
       wallets,

--- a/src/screens/migration/RecoverSeed.tsx
+++ b/src/screens/migration/RecoverSeed.tsx
@@ -9,20 +9,24 @@ import {
 } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useNavigation } from '@react-navigation/native'
+import type { StackNavigationProp } from '@react-navigation/stack'
 import { useSetRecoilState } from 'recoil'
 import RecoverWalletStore from 'stores/RecoverWalletStore'
 import { formatSeedStringToArray } from 'utils/wallet'
 import MigrationToolbar from 'components/migration/MigrationToolbar'
 import { COLORS } from 'consts/theme'
 import { useWalletNav } from 'navigation/hooks'
+import type { MigrationStackParams } from 'navigation/MigrationNavigator'
 import authStyles from '../auth/authStyles'
+
+type Nav = StackNavigationProp<MigrationStackParams, 'RecoverSeed'>
 
 const RecoverSeed = (): React.ReactElement => {
   const insets = useSafeAreaInsets()
-  const nav = useNavigation()
+  const nav = useNavigation<Nav>()
   const [seedText, setSeedText] = useState('')
   const setSeed = useSetRecoilState(RecoverWalletStore.seed)
-  const { startSeedRecovery, goHome } = useWalletNav()
+  const { goHome } = useWalletNav()
 
   const words = seedText.trim()
     ? formatSeedStringToArray(seedText)
@@ -32,7 +36,7 @@ const RecoverSeed = (): React.ReactElement => {
 
   const handleNext = (): void => {
     setSeed(words)
-    startSeedRecovery()
+    nav.navigate('VaultName', { mode: 'recover-seed' })
   }
 
   const handleBack = (): void => {


### PR DESCRIPTION
## Summary

- `RecoverSeed.handleNext` called the top-level `startSeedRecovery` hook, which only flips `rootRoute`/`migrationEntry`. The screen was already mounted inside `MigrationNavigator`, so `rootRoute` stayed `'Migration'` and the existing `Stack.Navigator` ignored the new `initialRouteName` (React Navigation only reads it on mount). Pressing **Next** did nothing.
- Navigate within the stack directly instead: `nav.navigate('VaultName', { mode: 'recover-seed' })`.
- Deletes the now-unused `startSeedRecovery` hook and its `'recover-seed'` `MigrationEntry` case in `index.tsx`, `hooks.ts`, and `MigrationNavigator.tsx` to prevent the same footgun from recurring. `MigrationMode = 'recover-seed'` (the screen param consumed by `KeygenProgress`) is unchanged.

Only call site of the buggy hook was `RecoverSeed.tsx:35`; scoped to that one flow. Both entry points into the screen (`AuthMenu`, `WalletList`) already call `startSeedRecoveryInput`, which correctly captures the pre-Migration origin in `preMigrationRootRef` for later `goHome()` — untouched by this fix.

## Test plan

- [ ] `npm run lint:check` passes
- [ ] `npm run typecheck` passes
- [ ] Manual: Auth menu → Recover → enter 12-word seed → Next lands on VaultName with recover-seed mode
- [ ] Manual: Auth menu → Recover → enter 24-word seed → Next lands on VaultName with recover-seed mode
- [ ] Manual: WalletList → Recover → enter seed → Next lands on VaultName with recover-seed mode
- [ ] Manual: full recover-seed flow (VaultName → VaultEmail → VaultPassword → KeygenProgress → VerifyEmail → MigrationSuccess) still completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)