### PR TITLE
fix(migration): update waiting screen copy per #61

### DIFF
--- a/src/components/migration/InfoCard.tsx
+++ b/src/components/migration/InfoCard.tsx
@@ -134,13 +134,9 @@ export default function InfoCard({
             </Text>
 
             <Text fontType="brockmann-medium" style={styles.body}>
-              Early explorers get{' '}
+              Be an early explorer and increase your chance for{' '}
               <Text fontType="brockmann-bold" style={styles.bodyBold}>
-                Station OG
-              </Text>{' '}
-              status and a{' '}
-              <Text fontType="brockmann-bold" style={styles.bodyBold}>
-                $VULT airdrop
+                rewards
               </Text>
               .
             </Text>


### PR DESCRIPTION
## Summary
- Updates the third paragraph of the migration waiting screen `InfoCard` to match the new copy from the Figma spec linked in the issue.
- Replaces "Early explorers get **Station OG** status and a **$VULT airdrop**." with "Be an early explorer and increase your chance for **rewards**."

Closes #61

## Test plan
- [ ] Open the migration waiting screen and confirm the third paragraph reads "Be an early explorer and increase your chance for **rewards**."
- [ ] Confirm surrounding copy ("A new type of wallet", "Faster transactions...", "Fast Vaults are the next evolution...", "Check back soon...", "Learn more about Vault security") is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)