### PR TITLE
fix(migration): add swipe-up hint chevron on RiveIntro

### DIFF
--- a/src/screens/migration/RiveIntro.tsx
+++ b/src/screens/migration/RiveIntro.tsx
@@ -16,6 +16,7 @@ import {
   StyleSheet,
 } from 'react-native'
 import { useNavigation } from '@react-navigation/native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import type { StackNavigationProp } from '@react-navigation/stack'
 import Svg, { Path } from 'react-native-svg'
 
@@ -23,12 +24,17 @@ import Text from 'components/Text'
 import { MIGRATION } from 'consts/migration'
 import type { MigrationStackParams } from 'navigation/MigrationNavigator'
 
-function ChevronUpIcon(): React.ReactElement {
+function ChevronUpIcon({
+  opacity = 1,
+}: {
+  opacity?: number
+}): React.ReactElement {
   return (
     <Svg width={20} height={12} viewBox="0 0 20 12" fill="none">
       <Path
         d="M2 10L10 2L18 10"
         stroke={MIGRATION.textTertiary}
+        strokeOpacity={opacity}
         strokeWidth={2}
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -64,6 +70,7 @@ type Nav = StackNavigationProp<MigrationStackParams, 'RiveIntro'>
 
 export default function RiveIntro(): React.ReactElement {
   const navigation = useNavigation<Nav>()
+  const insets = useSafeAreaInsets()
   const navigated = useRef(false)
 
   // Animated values for the exit transition — all native-driver compatible
@@ -227,6 +234,7 @@ export default function RiveIntro(): React.ReactElement {
       <Animated.View
         style={[
           styles.ctaWrap,
+          { paddingBottom: insets.bottom + 16 },
           {
             opacity: textOpacity,
             transform: [{ translateY: textTranslateY }],
@@ -234,17 +242,19 @@ export default function RiveIntro(): React.ReactElement {
         ]}
       >
         <Pressable onPress={goToHome} testID="enter-vultiverse-cta">
-          <Text style={styles.ctaText} fontType="brockmann-semibold">
-            Enter the Vultiverse
-          </Text>
           <Animated.View
             style={[
-              styles.chevron,
+              styles.chevronStack,
               { transform: [{ translateY: chevronBob }] },
             ]}
           >
+            <ChevronUpIcon opacity={0.5} />
+            <View style={styles.chevronSpacer} />
             <ChevronUpIcon />
           </Animated.View>
+          <Text style={styles.ctaText} fontType="brockmann-semibold">
+            Enter the Vultiverse
+          </Text>
         </Pressable>
       </Animated.View>
 
@@ -313,17 +323,21 @@ const styles = StyleSheet.create({
   },
   ctaWrap: {
     alignSelf: 'center',
-    paddingVertical: 12,
+    paddingTop: 12,
     paddingHorizontal: 24,
-    marginBottom: 16,
+    alignItems: 'center',
   },
   ctaText: {
     fontSize: 14,
     color: MIGRATION.textTertiary,
     lineHeight: 18,
+    marginTop: 12,
+    textAlign: 'center',
   },
-  chevron: {
+  chevronStack: {
     alignItems: 'center',
-    marginTop: 16,
+  },
+  chevronSpacer: {
+    height: 4,
   },
 })

--- a/src/screens/migration/RiveIntro.tsx
+++ b/src/screens/migration/RiveIntro.tsx
@@ -315,7 +315,7 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     paddingVertical: 12,
     paddingHorizontal: 24,
-    marginBottom: 60,
+    marginBottom: 16,
   },
   ctaText: {
     fontSize: 14,

--- a/src/screens/migration/RiveIntro.tsx
+++ b/src/screens/migration/RiveIntro.tsx
@@ -306,7 +306,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   spacerMid: {
-    flex: 0.9,
+    flex: 1.2,
   },
   textArea: {
     paddingHorizontal: 40,

--- a/src/screens/migration/RiveIntro.tsx
+++ b/src/screens/migration/RiveIntro.tsx
@@ -306,7 +306,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   spacerMid: {
-    flex: 0.5,
+    flex: 0.9,
   },
   textArea: {
     paddingHorizontal: 40,

--- a/src/screens/migration/RiveIntro.tsx
+++ b/src/screens/migration/RiveIntro.tsx
@@ -237,7 +237,7 @@ export default function RiveIntro(): React.ReactElement {
       <Animated.View
         style={[
           styles.ctaWrap,
-          { paddingBottom: insets.bottom + 16 },
+          { paddingBottom: insets.bottom + 32 },
           {
             opacity: textOpacity,
             transform: [{ translateY: textTranslateY }],

--- a/src/screens/migration/RiveIntro.tsx
+++ b/src/screens/migration/RiveIntro.tsx
@@ -324,6 +324,6 @@ const styles = StyleSheet.create({
   },
   chevron: {
     alignItems: 'center',
-    marginTop: 6,
+    marginTop: 16,
   },
 })

--- a/src/screens/migration/RiveIntro.tsx
+++ b/src/screens/migration/RiveIntro.tsx
@@ -207,8 +207,8 @@ export default function RiveIntro(): React.ReactElement {
         <View style={styles.walletAnimation} />
       )}
 
-      {/* Flexible space between wallet and text */}
-      <View style={styles.flex1} />
+      {/* Small breathing room between wallet and text */}
+      <View style={styles.spacerSmall} />
 
       {/* Text area — dissolves upward on transition */}
       <Animated.View
@@ -229,6 +229,9 @@ export default function RiveIntro(): React.ReactElement {
           }
         </Text>
       </Animated.View>
+
+      {/* Flexible space pushes text up, leaves CTA at bottom */}
+      <View style={styles.flex1} />
 
       {/* CTA — also dissolves out */}
       <Animated.View
@@ -301,6 +304,9 @@ const styles = StyleSheet.create({
   },
   flex1: {
     flex: 1,
+  },
+  spacerSmall: {
+    height: 24,
   },
   textArea: {
     paddingHorizontal: 40,

--- a/src/screens/migration/RiveIntro.tsx
+++ b/src/screens/migration/RiveIntro.tsx
@@ -207,8 +207,8 @@ export default function RiveIntro(): React.ReactElement {
         <View style={styles.walletAnimation} />
       )}
 
-      {/* Small breathing room between wallet and text */}
-      <View style={styles.spacerSmall} />
+      {/* Flexible space between wallet and text */}
+      <View style={styles.spacerMid} />
 
       {/* Text area — dissolves upward on transition */}
       <Animated.View
@@ -305,8 +305,8 @@ const styles = StyleSheet.create({
   flex1: {
     flex: 1,
   },
-  spacerSmall: {
-    height: 24,
+  spacerMid: {
+    flex: 0.5,
   },
   textArea: {
     paddingHorizontal: 40,

--- a/src/screens/migration/RiveIntro.tsx
+++ b/src/screens/migration/RiveIntro.tsx
@@ -234,6 +234,9 @@ export default function RiveIntro(): React.ReactElement {
         ]}
       >
         <Pressable onPress={goToHome} testID="enter-vultiverse-cta">
+          <Text style={styles.ctaText} fontType="brockmann-semibold">
+            Enter the Vultiverse
+          </Text>
           <Animated.View
             style={[
               styles.chevron,
@@ -242,9 +245,6 @@ export default function RiveIntro(): React.ReactElement {
           >
             <ChevronUpIcon />
           </Animated.View>
-          <Text style={styles.ctaText} fontType="brockmann-semibold">
-            Enter the Vultiverse
-          </Text>
         </Pressable>
       </Animated.View>
 
@@ -324,6 +324,6 @@ const styles = StyleSheet.create({
   },
   chevron: {
     alignItems: 'center',
-    marginBottom: 6,
+    marginTop: 6,
   },
 })

--- a/src/screens/migration/RiveIntro.tsx
+++ b/src/screens/migration/RiveIntro.tsx
@@ -1,6 +1,12 @@
-import React, { useCallback, useRef, useState } from 'react'
+import React, {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import {
   Animated,
+  Easing,
   NativeModules,
   PanResponder,
   PixelRatio,
@@ -11,10 +17,25 @@ import {
 } from 'react-native'
 import { useNavigation } from '@react-navigation/native'
 import type { StackNavigationProp } from '@react-navigation/stack'
+import Svg, { Path } from 'react-native-svg'
 
 import Text from 'components/Text'
 import { MIGRATION } from 'consts/migration'
 import type { MigrationStackParams } from 'navigation/MigrationNavigator'
+
+function ChevronUpIcon(): React.ReactElement {
+  return (
+    <Svg width={20} height={12} viewBox="0 0 20 12" fill="none">
+      <Path
+        d="M2 10L10 2L18 10"
+        stroke={MIGRATION.textTertiary}
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  )
+}
 
 // Skip Rive only under Detox — its native runtime keeps the iOS main
 // run loop busy, blocking Detox idle detection. Normal dev mode loads it.
@@ -54,6 +75,32 @@ export default function RiveIntro(): React.ReactElement {
 
   // Show the background Rive only after gesture starts
   const [showBgTransition, setShowBgTransition] = useState(false)
+
+  // Looping bob for the swipe-up hint chevron
+  const chevronBob = useRef(new Animated.Value(0)).current
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(chevronBob, {
+          toValue: -6,
+          duration: 700,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+        Animated.timing(chevronBob, {
+          toValue: 0,
+          duration: 700,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+      ])
+    )
+    loop.start()
+    return (): void => {
+      loop.stop()
+    }
+  }, [chevronBob])
 
   const goToHome = useCallback(() => {
     if (navigated.current) return
@@ -187,6 +234,14 @@ export default function RiveIntro(): React.ReactElement {
         ]}
       >
         <Pressable onPress={goToHome} testID="enter-vultiverse-cta">
+          <Animated.View
+            style={[
+              styles.chevron,
+              { transform: [{ translateY: chevronBob }] },
+            ]}
+          >
+            <ChevronUpIcon />
+          </Animated.View>
           <Text style={styles.ctaText} fontType="brockmann-semibold">
             Enter the Vultiverse
           </Text>
@@ -266,5 +321,9 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: MIGRATION.textTertiary,
     lineHeight: 18,
+  },
+  chevron: {
+    alignItems: 'center',
+    marginBottom: 6,
   },
 })


### PR DESCRIPTION
## Summary
- The Vultiverse intro screen has a hidden swipe-up gesture (`PanResponder` with a 50px threshold) but no visual cue, so users aren't sure how to advance.
- Adds a small chevron-up icon directly above the "Enter the Vultiverse" CTA, with a subtle looping vertical bob (0 → -6px, 700ms ease-in-out, native-driver) to telegraph the swipe.
- The chevron sits inside the existing CTA wrap so it dissolves out with the rest of the text on transition — no impact on the exit animation.

Refs #61 (the second checkbox — "Animation to screen transition needs to be cleaner"). The first checkbox (copy text) is handled in #62.

## Test plan
- [ ] Open the app, get to the RiveIntro screen.
- [ ] Confirm a small chevron-up icon appears above "Enter the Vultiverse" and bobs gently up and down on a continuous loop.
- [ ] Swipe up → confirm the chevron fades/translates out cleanly with the rest of the CTA text (no visual artifact at the seam).
- [ ] Tap "Enter the Vultiverse" → same exit animation behavior as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)