### PR TITLE
docs(airdrop): cross-team contract for quests + grounding pass against actual repos

### DIFF
--- a/docs/airdrop-specs/overview.md
+++ b/docs/airdrop-specs/overview.md
@@ -60,7 +60,7 @@ The operator also loads the same list into our database so the app's status endp
 
 ### 3. Day 13–27, watch what users do in the app and tick off quests
 
-Every time the mobile app reports back "the user just signed and broadcast a transaction" (this is an existing notification the app already sends to the backend after every tool call), we look at what kind of transaction it was. If it was a swap above $10, we tick the "swap quest" box for that user. If it was a bridge, we tick "bridge quest." Etc.
+Every time the mobile app reports back "the user just signed and broadcast a transaction" (the existing tx-proposal `/sign` call), the backend looks up what kind of transaction it was. The agent already tagged the proposal at creation time with a tool name (`build_swap_tx`, `build_evm_tx`, etc.) and a small `quest_metadata` blob containing normalised data (USD value, source/destination chains, target contract). If it was a swap above $10, we tick the "swap quest" box for that user. If it was a bridge, we tick "bridge quest." Etc.
 
 Once any user has 3 of 5 quests ticked, they're flagged as `claim_eligible` in the database.
 
@@ -90,7 +90,7 @@ Behind a username/password.
 
 ## What the on-chain contract does
 
-Lives in a separate repo (`vultisig/mergecontract`), built by someone else:
+Lives in a separate repo (`vultisig/vultisig-contract`), built by someone else:
 - Holds the VULT prize pool.
 - Holds an `allowance` mapping — for each winner address, how much VULT they can claim.
 - Has a `setWinners(addresses[], amounts[])` function the multisig owner calls in batches to populate that mapping after the Day 12 draw.

--- a/docs/airdrop-specs/shared-concerns.md
+++ b/docs/airdrop-specs/shared-concerns.md
@@ -14,11 +14,12 @@ If you're picking up a stage and find yourself building something that "feels ge
 
 A single engineer can ship the whole pipeline in roughly this sequence. Stages have hard external deadlines (Day 8, 12, 13, 28); shared infra has none, so it slots in wherever attention is available.
 
-1. **This doc + the shared infra it scopes** (auth middleware, env-var loader, KMS signer, EVM client). Roughly a day's work; no external dependencies.
-2. **Stage 1 — Boarding.** Hard deadline Day 8. Must be live in staging first.
+0. **Cross-team prerequisite for Stage 3.** MCP team adds `quest_metadata` to `build_*` tool results; agent-backend team adds `tool_name` + `quest_metadata` columns to `agent_tx_proposals` and populates them at proposal-creation time. **Hard blocker for Stage 3.** Schema in `stage-3-quest-tracking.md` "Cross-team contract" section. Slot in early — both PRs need to merge before Stage 3 can be E2E-tested.
+1. **This doc + the shared infra it scopes** (internal-token middleware, env-var loader, KMS signer, EVM client, eligibility helper). Roughly a day's work; no external dependencies.
+2. **Stage 1 — Boarding.** Hard deadline Day 8. Must be live in staging first. First consumer of `eligibility.go`.
 3. **Stage 2 — Raffle Draw CLI.** Doesn't deploy as a service; can be developed in parallel with Stage 3 once Stage 1 is in staging. One subcommand (`draw`) plus `load-winners` and `verify-onchain` helpers.
-4. **Stage 3 — Quest Tracking.** Needs the runtime hook into the existing `tool-result` handler — coordinate with the agent codebase's review cycle.
-5. **Stage 4 — Claim Relayer.** Depends on Stage 2's `agent_raffle_winners` table existing and on Stage 3's `eligibility.go` helper.
+4. **Stage 3 — Quest Tracking.** Hooks into the existing `SignTxProposal` handler (`internal/api/tx_proposals.go`), reading `tool_name` + `quest_metadata` from the just-signed proposal row. Blocked on item 0.
+5. **Stage 4 — Claim Relayer.** Depends on Stage 2's `agent_raffle_winners` table existing and reuses `eligibility.go` from shared infra.
 
 Sibling missions run in parallel:
 - **Mobile app** (`sibling-mobile-app.md`) needs the Stage 1 endpoints in staging by Day 8 to wire up boarding.
@@ -33,7 +34,7 @@ Three distinct auth mechanisms, each owning a clear path prefix:
 | Surface | Auth | Used by | Implemented in |
 |---|---|---|---|
 | `/airdrop/register`, `/airdrop/status`, `/airdrop/claim` | JWT (existing `/auth/token` flow — vault ECDSA sig → 24h JWT) | Mobile app | Existing `internal/api/middleware.go` — no changes needed |
-| `/internal/quests/event`, `/internal/relayer/balance`, `/internal/relayer/stuck-claims` | `X-Internal-Token: <secret>` matching `INTERNAL_API_KEY` env var | Other parts of the same service binary (executor.go), curl by ops | New: `internal/api/middleware/internal_token.go` |
+| `/internal/quests/event` | `X-Internal-Token: <secret>` matching `INTERNAL_API_KEY` env var | The agent-backend's `SignTxProposal` handler (in this same binary), curl by ops | New: `internal/api/internal_token_middleware.go` |
 | `/ops/*` (HTML pages, including `POST /ops/rebroadcast`) | HTTP Basic Auth via `OPS_USERNAME` + `OPS_PASSWORD` env vars | Operator's browser, or curl-from-script | Inlined: 5-line stdlib check in the ops handler |
 | `/airdrop/stats` | None (public) | Marketing | n/a |
 | `/healthz` | None (existing) | Load balancer | Existing |
@@ -80,18 +81,19 @@ Six new tables, one shared types prefix (`airdrop_*` for Postgres enums). All na
 |---|---|---|---|
 | `agent_airdrop_registrations` | 1 | One row per user who joined the raffle | `public_key` (PK), `source`, `recipient_address`, `registered_at` |
 | `agent_raffle_winners` | 2 | One row per winner; populated by `load-winners` CLI. Mirrors the contract's on-chain `allowance` mapping for status display. | `public_key` (PK), `recipient`, `amount`, `loaded_at` |
-| `agent_quest_events` | 3 | Append-only audit log of incoming quest events (counted + rejected) | `tool_call_id` (PK), `public_key`, `quest_id`, `tx_hash`, `status`, `payload`, `created_at` |
+| `agent_quest_events` | 3 | Append-only audit log of incoming quest events (counted + rejected) | `tool_call_id` (PK), `public_key`, `quest_id`, `tx_hash`, `counted` (bool), `reject_reason`, `tx_proposal_id`, `created_at` |
 | `agent_user_quests` | 3 | Materialized "which quests has each user completed" | `(public_key, quest_id)` (PK), `completed_at` |
-| `agent_claim_submissions` | 4 | One row per claim attempt; lifecycle from submitted → confirmed/failed | `nonce` (UNIQUE), `public_key`, `recipient`, `amount`, `tx_hash`, `previous_tx_hashes[]`, `status`, gas fields, timestamps |
+| `agent_claim_submissions` | 4 | One row per claim attempt; lifecycle from submitted → confirmed/failed. Rebroadcasts update `tx_hash` in place. | `nonce` (UNIQUE), `public_key`, `recipient`, `amount`, `tx_hash`, `status`, gas fields, timestamps |
 | `agent_relayer_state` | 4 | Singleton holding the relayer's `next_nonce` counter | `id=1` (CHECK), `next_nonce`, `last_synced` |
 
-Plus four Postgres enum types:
+Plus three Postgres enum types:
 - `airdrop_registration_source` — `seed`, `vault_share`
 - `airdrop_quest_id` — `swap`, `bridge`, `defi_action`, `alert`, `dca`
-- `airdrop_quest_event_status` — `counted`, `rejected`
 - `airdrop_claim_status` — `submitted`, `confirmed`, `failed`
 
 No foreign keys between airdrop tables — the relationships are by `public_key` value only. This keeps each migration independent and avoids ordering games at deploy time.
+
+**Cross-cutting note:** Stage 3 also depends on two new columns on the existing `agent_tx_proposals` table — `tool_name TEXT` and `quest_metadata JSONB` — populated by the agent-backend at proposal-creation time. Those columns aren't airdrop-owned and the migration that adds them lives in the agent-backend team's PR (see Stage 3 plan Task 0). Listed here for cross-cutting visibility.
 
 ### Migration ordering
 
@@ -112,13 +114,13 @@ Each migration is a single `CREATE TABLE` (plus `CREATE TYPE` for enums where ne
 
 Code that should live in one place even though multiple stages use it.
 
-### `internal/api/middleware/internal_token.go`
+### `internal/api/internal_token_middleware.go`
 
 ```
-func InternalTokenAuth(secret string) echo.MiddlewareFunc
+func (s *Server) InternalTokenMiddleware(next echo.HandlerFunc) echo.HandlerFunc
 ```
 
-Reads `X-Internal-Token` header, compares to `secret` (constant-time), 401 on mismatch. Used by Stage 3 (`/internal/quests/event`) and Stage 4 (`/internal/relayer/*`).
+Reads `X-Internal-Token` header, compares to `s.internalToken` (constant-time), 401 on mismatch. Used by Stage 3 (`/internal/quests/event`). Stage 4's ops health and stuck-claims views are served directly from `/ops/*` over Basic Auth — no `/internal/relayer/*` route group exists.
 
 ### `internal/service/airdrop/quests/eligibility.go`
 
@@ -127,6 +129,8 @@ func IsClaimEligible(ctx context.Context, db DB, publicKey string) (eligible boo
 ```
 
 Computes the composite from `agent_raffle_winners`, `agent_user_quests`, and `agent_claim_submissions`. Returns a `reason` string for logging when eligible == false (`"not_a_winner"`, `"only_2_quests_complete"`, `"already_claimed"`, etc.). Called inline by Stage 1's status handler and Stage 4's claim handler — pure DB read, no HTTP boundary.
+
+**Owned by Stage 1's plan** (Stage 1 is the first consumer); listed here because Stages 3 + 4 both reuse it. Don't duplicate in stage-specific code.
 
 ### `internal/service/airdrop/kms/signer.go`
 
@@ -154,6 +158,7 @@ type Client interface {
     GetTransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
     BalanceOf(ctx context.Context, token, account common.Address) (*big.Int, error)
     Balance(ctx context.Context, account common.Address) (*big.Int, error)
+    BlockNumber(ctx context.Context) (uint64, error)
 }
 
 func NewClient(rpcURL string) (Client, error)
@@ -167,7 +172,7 @@ Thin wrapper over `go-ethereum/ethclient.Client` exposing only the methods the r
 
 Three artifacts cross repo boundaries. All need to be locked early to avoid late surprises.
 
-### Backend ↔ `vultisig/mergecontract`
+### Backend ↔ `vultisig/vultisig-contract`
 
 **Inbound:** compiled `AirdropClaim.sol` ABI, deployed mainnet address, local Foundry/Anvil deployment fixture for backend integration tests against a fork.
 
@@ -207,18 +212,19 @@ To keep scope clear:
 - Operational runbooks (Day 12 raffle runbook, Day 28 relayer bringup, oracle key rotation — all are stage-specific or have been removed). They live in `docs/runbooks/` once written.
 - The contract source code or contract repo conventions (covered by `sibling-on-chain-contract.md`).
 - The mobile app UI implementation (covered by `sibling-mobile-app.md`).
-- Anything in the existing `agent-backend` codebase that doesn't change — the existing JWT middleware, the existing tool-result handler, the `cmd/server` entrypoint, etc.
+- Anything in the existing `agent-backend` codebase that doesn't change — the existing JWT middleware, the existing `SignTxProposal` handler (which Stage 3 hooks into additively), the `cmd/server` entrypoint, etc.
 
 ---
 
 ## Done when
 
-- The three shared Go packages above exist and have unit tests.
+- The four shared Go packages above exist and have unit tests (internal-token middleware, eligibility helper, KMS signer, ETH client).
 - The six migrations exist and apply cleanly on a fresh DB in order.
 - The 19 env vars are loadable from the existing config struct without errors.
 - Internal-token middleware rejects missing/wrong tokens with 401; accepts correct tokens.
-- Basic Auth middleware returns the `WWW-Authenticate: Basic` challenge on missing creds.
 - KMS signer can sign a no-op digest against a real (LocalStack) KMS key and the recovered EVM address matches.
-- ETH client can read the latest base fee against a public mainnet RPC.
+- ETH client can read the latest base fee + block number against a public mainnet RPC.
+
+(Basic Auth coverage lives in Stage 4 — it's inlined in the ops handler, not part of shared infra.)
 
 Once those tick, the per-stage work has the foundations it needs.

--- a/docs/airdrop-specs/sibling-mobile-app.md
+++ b/docs/airdrop-specs/sibling-mobile-app.md
@@ -10,7 +10,7 @@ The same mental model as the backend specs: plain-English context up top, concre
 
 ## What's already shipped
 
-A lot of the rebrand and migration work has already landed (PRs #38–#63 in `StationWallet/station-mobile`). The relevant pieces:
+A lot of the rebrand and migration work has already landed (PRs #38–#63 in `StationWallet/station-mobile`, now `vultisig/vultiagent-app` after the rebrand). The relevant pieces:
 
 - **RiveIntro screen** (PR #63) — the Vultiverse-themed Rive animation with the swipe-up-to-board gesture and the chevron hint.
 - **Migration flow** (PRs #38, #41, #42, #44, #45, #51, #52, #54) — Station → Fast Vault import via seed phrase or vault share. Lands the user with a working Fast Vault.
@@ -87,15 +87,17 @@ The Fast Vault has an ECDSA public key. EVM address is the standard Ethereum der
 3. Take the last 20 bytes.
 4. Format with `0x` prefix → that's the EVM address.
 
-The Vultisig SDK / wallet-core / mpc-native package the app already uses for Ethereum operations exposes this derivation directly — use the existing helper, do not hand-roll.
+**Existing helper:** `deriveEthAddress(compressedPubKeyHex, hexChainCode?)` at `vultiagent-app/src/services/auth/addressDerivation.ts:50`. Uses secp256k1 + keccak256, returns the standard 20-byte EVM address. Reuse it directly — do not hand-roll.
 
 ### Legacy Terra-only case
 
 A subset of legacy Station Wallet vaults are **Terra-only** — the original Station Wallet only exposed Terra keys, and even after migration to a Fast Vault, the resulting vault structure may not have a usable ECDSA key from which an EVM address can be derived.
 
+> **Net-new logic.** The vultiagent-app codebase has no existing "is this vault Terra-only" check, no fallback prompt UI. `deriveEthAddress` (at `src/services/auth/addressDerivation.ts:50`) handles the standard ECDSA path but throws on missing keys without a graceful UI fallback. This whole subsection is net-new mobile work — flag in the mobile-engineer's task scope, not bundled into the existing migration flow PRs.
+
 For these vaults the app must:
 
-1. Detect the Terra-only condition during the post-migration `recipient_address` computation step. Concretely: attempt the ECDSA derivation; if no usable key is available, fall through to the prompt path.
+1. Detect the Terra-only condition during the post-migration `recipient_address` computation step. Concretely: attempt the ECDSA derivation; if it throws or returns no usable key, fall through to the prompt path. Suggest adding a small `isTerraOnlyVault(vault)` helper alongside the existing derivation code.
 2. Show a UI prompting the user for an EVM address: "Where would you like to receive your VULT? Paste an Ethereum address." Include explainer copy (e.g. "this is because your vault was migrated from a Terra-only wallet").
 3. Validate format client-side: must match `^0x[a-fA-F0-9]{40}$`.
 4. Send that address as `recipient_address` in the `POST /airdrop/register` call.

--- a/docs/airdrop-specs/sibling-on-chain-contract.md
+++ b/docs/airdrop-specs/sibling-on-chain-contract.md
@@ -2,9 +2,9 @@
 
 ## What this spec covers
 
-The Solidity contract that holds the VULT prize pool, accepts a per-recipient allowance map from the multisig owner, and pays VULT to claiming winners. **Owned by the contract engineer** (separate engineer, in the existing `vultisig/mergecontract` repo). Documented here so the backend ↔ contract interface is shared and both teams can review.
+The Solidity contract that holds the VULT prize pool, accepts a per-recipient allowance map from the multisig owner, and pays VULT to claiming winners. **Owned by the contract engineer** (separate engineer, in the existing `vultisig/vultisig-contract` repo). Documented here so the backend ↔ contract interface is shared and both teams can review.
 
-The contract is a fork of the team's existing `ETHClaim.sol` per the campaign deck, simplified during the 2026-04-22 (eligibility moves backend-side) and 2026-04-23 (Merkle dropped in favour of an on-chain mapping) spec passes.
+The contract is net-new code in `vultisig/vultisig-contract` (no existing `ETHClaim.sol` to fork from — the campaign deck's reference was aspirational). Patterns follow the team's existing contracts in that repo (`Stake.sol`, `Token.sol`, `LaunchList.sol`) — Foundry-built, OZ ^5.2.0, Solidity ^0.8.28. The simplified surface (mapping-based allowance + setWinners + claim) reflects the 2026-04-22 (eligibility moves backend-side) and 2026-04-23 (Merkle dropped) decisions.
 
 ---
 
@@ -22,9 +22,9 @@ What remains is a minimal allowance-based claim contract — about 30 lines of S
 
 ## Tech stack
 
-- Solidity ^0.8.20+
-- Foundry (`forge` for tests, `cast` for deploy)
-- OpenZeppelin contracts: `Ownable`, `SafeERC20`
+- Solidity ^0.8.28 (matches existing `Token.sol` in vultisig-contract)
+- Foundry (`forge` for tests, `cast` for deploy) — `foundry.toml` already in repo root
+- OpenZeppelin contracts ^5.2.0 (already vendored under `lib/openzeppelin-contracts`): `Ownable`, `SafeERC20`
 - Ethereum mainnet (chain ID 1)
 
 ---
@@ -142,7 +142,7 @@ The "Day 0 → Day 28 critical path" from the contract side:
 5. **Backend (Stage 2)** runs the raffle CLI on Day 12; produces `winners.csv`.
 6. **Multisig calls `setWinners(addresses, amounts)`** in batched chunks (~100/batch, ~7 txs total for 700 winners) before the relayer goes live on Day 28.
 7. **Backend (Stage 4)** relayer goes live; starts processing claims.
-8. **End of campaign**: multisig calls `recoverERC20` to pull unclaimed VULT back to treasury.
+8. **End of campaign**: backend operator flips `CLAIM_ENABLED=false` so the relayer stops accepting new claims. Multisig then calls `recoverERC20(VULT_TOKEN, vult.balanceOf(thisContract), treasuryAddress)` to drain unclaimed VULT back to treasury. The contract is then dormant — no `selfdestruct`, no upgrade path. Stays deployed indefinitely so the public can verify the historical state on Etherscan.
 
 Setup gas (one-time): ~700k for deploy + ~18M total across the setWinners batches ≈ **~$2k at 30 gwei** (~$6k at 100 gwei spike). Treasury should be aware of this Day 12 burn.
 
@@ -175,9 +175,11 @@ Setup gas (one-time): ~700k for deploy + ~18M total across the setWinners batche
 
 ## Open dependencies
 
-- VULT token deployed at a known address (separate concern, presumably already done).
-- Multisig owner address known (probably already exists for other Vultisig contracts).
+- **VULT token mainnet address — UNKNOWN.** `Token.sol` exists in `vultisig-contract` but no deployment config in the repo references a deployed mainnet address. Must be confirmed with whoever holds the VULT token contract before deploy. Hard blocker for the constructor.
+- **Multisig owner address — UNKNOWN.** No precedent in the repo's existing `script/Deploy*.s.sol` files. Must be confirmed with whoever holds the Vultisig treasury multisig. Hard blocker for the constructor's `_initialOwner` argument.
 - Free public Ethereum RPC for backend integration testing — operator concern.
+
+Both UNKNOWN items are tracked in Stage 0's procurement section as hard prerequisites (see `stage-0-preflight.md`).
 
 ---
 

--- a/docs/airdrop-specs/stage-0-preflight.md
+++ b/docs/airdrop-specs/stage-0-preflight.md
@@ -32,6 +32,7 @@ Engineering-side decisions (don't need Founder, but lock before deploy):
 | 9 | KMS provider | AWS KMS | Eng lead |
 | 10 | Stuck-tx auto-bump in v1 | No (manual re-broadcast) | Eng lead |
 | 11 | Raffle randomness source | `crypto/rand` u64 seed, recorded in the post-draw manifest for audit | Eng lead |
+| 12 | `quest_metadata` JSONB schema locked across MCP, agent-backend, and airdrop teams | Schema in `stage-3-quest-tracking.md` "Cross-team contract" section | MCP eng + agent-backend eng + airdrop eng |
 
 ---
 
@@ -55,16 +56,33 @@ Engineering-side decisions (don't need Founder, but lock before deploy):
 
 ## Cross-mission alignment
 
-- [ ] **mergecontract ownership decided.**
-  - What: Decide whether the Solidity work in `vultisig/mergecontract` is mine end-to-end or a teammate's. Determines whether the next item is "write the contract" or "agree the spec with them."
-  - Done when: Assignment is named in writing — Slack, this doc, or a GitHub issue on mergecontract.
+- [ ] **vultisig-contract ownership decided.**
+  - What: Decide whether the Solidity work in `vultisig/vultisig-contract` is mine end-to-end or a teammate's. Determines whether the next item is "write the contract" or "agree the spec with them."
+  - Done when: Assignment is named in writing — Slack, this doc, or a GitHub issue on vultisig-contract.
+  - Note: there is no existing `ETHClaim.sol` in `vultisig-contract` to fork from (campaign deck reference was aspirational). `AirdropClaim.sol` is net-new; pattern after the repo's existing `Stake.sol` / `Token.sol` style.
+
+- [ ] **Multisig owner address captured.**
+  - What: The mainnet address of the Vultisig multisig that will own `AirdropClaim.sol` — passed as the constructor's `_initialOwner` and the only address authorised to call `setWinners`, `closeRaffle`, `recoverERC20`. No precedent for this address in `vultisig/vultisig-contract`'s existing `script/Deploy*.s.sol` files, so it must be confirmed externally with the treasury team.
+  - Done when: address is recorded in this doc and in `script/DeployAirdropClaim.s.sol` (or the deploy `.env`).
+  - Depends on: nothing — pure ask.
+
+- [ ] **VULT mainnet token address captured.**
+  - What: The deployed mainnet ERC-20 address of VULT. `Token.sol` exists in `vultisig-contract` but no deployment config references a deployed address — must be confirmed with whoever holds the VULT token contract.
+  - Done when: address is recorded in this doc and in `script/DeployAirdropClaim.s.sol` (or the deploy `.env`). The contract's constructor `_vult` argument is fed from this.
+  - Depends on: nothing — pure ask.
+  - Why both this and the previous item are blockers: the `AirdropClaim.sol` constructor takes both as required arguments. Without them, the deploy script is incomplete.
+
+- [ ] **`quest_metadata` cross-team contract locked.**
+  - What: The `agent_tx_proposals.quest_metadata` JSONB shape is agreed and committed by all three teams (MCP server, agent-backend, airdrop eng). Schema lives in `stage-3-quest-tracking.md` "Cross-team contract" section. MCP-side build_* tools emit it; agent-backend-side scheduler.go writes it to the new column at proposal-creation time.
+  - Done when: PR open in `vultisig/mcp` adding `quest_metadata` to at least `build_swap_tx` and `build_evm_tx` results; PR open in `vultisig/agent-backend` adding the migration + scheduler.go change. Both reviewed and merged before Stage 3 ships.
+  - Why this is Stage 0: Stage 3 is hard-blocked on this. Without `quest_metadata`, the airdrop module has no reliable way to classify or evaluate a tx and quest tracking can't function.
 
 - [ ] **App team API shapes confirmed.**
   - What: Whoever's building the agent-app registration + status UI agrees the request/response shapes for `POST /airdrop/register`, `GET /airdrop/status`, `POST /airdrop/claim`.
   - Done when: A short shared doc or OpenAPI fragment is pinned somewhere both teams can see, and the app team can mock against it.
 
 - [ ] **Artifact storage repo identified.**
-  - What: A private repo (or a folder in `vultisig/mergecontract`) where the operator commits the Day 12 raffle artifacts (`winners.csv`, `manifest.json`) for durability + audit. Multisig signer pulls `winners.csv` from here to construct the batched `setWinners(...)` calls.
+  - What: A private repo (or a folder in `vultisig/vultisig-contract`) where the operator commits the Day 12 raffle artifacts (`winners.csv`, `manifest.json`) for durability + audit. Multisig signer pulls `winners.csv` from here to construct the batched `setWinners(...)` calls.
   - Done when: Repo path is named, operator has push access, decision recorded in this doc.
 
 ---
@@ -79,7 +97,7 @@ Engineering-side decisions (don't need Founder, but lock before deploy):
 - [ ] **VULT prize pool funded.**
   - What: `slot_count × amount_per_winner × 1.05` VULT, sent to the deployed `AirdropClaim.sol` contract.
   - Done when: Tokens visible at the contract address on Etherscan; multisig owner confirms.
-  - Depends on: Decisions table rows 1–2 locked; mergecontract deployed (separate mission).
+  - Depends on: Decisions table rows 1–2 locked; vultisig-contract deployed (separate mission).
 
 ---
 

--- a/docs/airdrop-specs/stage-2-raffle-draw.md
+++ b/docs/airdrop-specs/stage-2-raffle-draw.md
@@ -14,7 +14,7 @@ The contract is the source of truth for who's a winner. The backend's `agent_raf
 
 1. Boarding window closes at `TRANSITION_WINDOW_END`.
 2. Operator runs `airdrop-raffle draw --seed <int>`. CLI emits `winners.csv` and `manifest.json` to a local output directory.
-3. Operator commits the artifact directory to a private ops repo (or `vultisig/mergecontract`) for durability + audit trail.
+3. Operator commits the artifact directory to a private ops repo (or `vultisig/vultisig-contract`) for durability + audit trail.
 4. Operator hands `winners.csv` to the multisig signer.
 5. Multisig signer reviews the CSV (row count, eyeball spot-check), splits it into batches of ~100, and calls `AirdropClaim.setWinners(addresses, amounts)` once per batch (~7 txs total for 700 winners).
 6. Operator runs `airdrop-raffle load-winners --output-dir <dir>`. Inserts every winner into `agent_raffle_winners` in a single transaction. Stage 1's `/airdrop/status` endpoint immediately starts returning `won` / `lost` to all users.
@@ -35,6 +35,20 @@ This is "trust Vultisig but verifiable after the fact" rather than "trustless vi
 ## Recipient address
 
 `recipient` for each winner is read directly from `agent_airdrop_registrations.recipient_address` — the column is `NOT NULL`, captured client-side at registration time (see Stage 1). The CLI never derives, never inspects vault internals, never falls back. If the registration row is missing for some reason, that's a hard error.
+
+### Correcting a wrong winner address
+
+If a winner's recipient address turns out to be wrong (mobile-app derivation bug, user complaint about a typo, lost wallet), the multisig can fix it by calling `setWinners([wrongWinnerAddress, correctWinnerAddress], [0, originalAmount])`. Setting the wrong address's allowance to 0 effectively revokes it; setting the new address's allowance to the original amount re-arms the claim there. The relayer then sees the corrected address on next claim.
+
+This works because `setWinners` is repeatable and doesn't track who's been "officially registered" beyond the mapping itself. The operational guard is the multisig's own checklist: never re-arm an already-claimed address (ops should diff against confirmed `Claimed` events on Etherscan before re-running setWinners).
+
+After correcting on-chain, also update the local `agent_raffle_winners` row with the new `recipient` so the `/airdrop/status` response matches:
+
+```sql
+UPDATE agent_raffle_winners SET recipient = '0xCORRECT' WHERE public_key = 'pk1';
+```
+
+A small `airdrop-raffle update-recipient --public-key X --new-recipient 0xY` subcommand could wrap this; deferred until ops actually hits the case.
 
 ---
 
@@ -139,7 +153,7 @@ No `leaf` or `proof[]` columns — those were Merkle artifacts and are gone.
 
 No new env vars. All inputs are CLI flags so the same binary can target dev / staging / prod by varying the flags rather than swapping config.
 
-Artifact durability is achieved by the operator committing the output directory to a private ops repo (or `vultisig/mergecontract`) after the draw — same audit trail as a versioned bucket, no AWS dependency in the CLI.
+Artifact durability is achieved by the operator committing the output directory to a private ops repo (or `vultisig/vultisig-contract`) after the draw — same audit trail as a versioned bucket, no AWS dependency in the CLI.
 
 ---
 
@@ -170,7 +184,7 @@ This is a CLI, not a service — no Prometheus surface. Observability is:
 - `verify-onchain` against an Anvil-deployed `AirdropClaim` with full + matching mapping → all pass.
 - `verify-onchain` against an Anvil-deployed `AirdropClaim` with deliberately-missing entries → reports the gaps non-zero.
 
-**End-to-end (with `mergecontract`):**
+**End-to-end (with `vultisig-contract`):**
 - `draw` → operator splits `winners.csv` and calls `setWinners` in batches against a Foundry-deployed `AirdropClaim.sol` → `verify-onchain` passes → `load-winners` → claim flow (Stage 4) succeeds for a sample winner.
 
 ---
@@ -200,7 +214,7 @@ No more `leaf_encoding.go`, `merkle.go`. Both deleted along with the cross-langu
 ## Open dependencies
 
 - **Stage 0 — `slot_count` and `vult_amount` decisions locked.** These are CLI flags; without locked values the CLI can run against placeholders in dev but won't ship to mainnet.
-- **Stage 0 — private ops repo (or `mergecontract`) available to the operator** for committing artifact directories post-draw.
+- **Stage 0 — private ops repo (or `vultisig-contract`) available to the operator** for committing artifact directories post-draw.
 - **Stage 1 — `recipient_address` column populated.** Done — see Stage 1 spec.
 - **Stage 4 — relayer reads `agent_raffle_winners`.** This spec defines the table; Stage 4 spec consumes it.
 - **`AirdropClaim.sol` deployed and `setWinners` callable** by the multisig before Day 28. The `verify-onchain` subcommand depends on the contract being live.

--- a/docs/airdrop-specs/stage-3-quest-tracking.md
+++ b/docs/airdrop-specs/stage-3-quest-tracking.md
@@ -4,27 +4,70 @@
 
 Winning the raffle doesn't immediately get the user VULT. Winners must complete **3 of 5 in-app activities** during Days 13–27 first — swap a token, bridge between chains, do a DeFi action, set up an alert, set up a DCA. This filters bots and rewards engagement before payout.
 
-We watch what users do in the agent: every time the mobile app reports back that a tool call's transaction was signed and broadcast (the existing `POST /conversations/{id}/tool-result` notification), we check whether it counts toward a quest. If so, we record an event and mark the quest complete for that user. Once a user hits 3 quests, they're flagged `claim_eligible` in the database — Stage 4's relayer reads that flag before submitting any on-chain claim.
+Every time a user signs and broadcasts a transaction the agent built for them, the agent-backend's existing tx-proposal `/sign` handler fires a quest event into the airdrop module. The event includes a normalised `quest_metadata` payload that the agent layer pre-computed at proposal-creation time (USD value, chain IDs, target contract). The airdrop module then runs the per-quest validator against that payload and, if it qualifies, marks the quest complete. Once a user hits 3 quests they're flagged `claim_eligible`; Stage 4's relayer reads that flag before submitting any on-chain claim.
 
 **Eligibility is enforced backend-side, not on-chain.** The contract trusts the relayer to only submit claims for eligible users. Since the backend is the only relayer and a backend compromise would also compromise any on-chain attestation key, an EIP-712 attestation step would add complexity without meaningful security. (Decision recorded 2026-04-22.)
 
 This stage is alive between Day 13 and Day 27 (the quest-earning window) and the eligibility data continues to be readable indefinitely after that for late claims.
 
+> **2026-04-23 update.** The classifier-based design (sniffing JSONB at quest-event time) was dropped in favour of the agent layer pre-computing a normalised `quest_metadata` field at proposal-creation time. The change moves the work to where the truth lives — the build_* tool that built the tx already knows the USD amount, the route, the target contract. Ripping classification logic out of the airdrop module and replacing it with a clean lookup table is both simpler and more reliable. See "Cross-team contract" below.
+
 ---
 
 ## The 5 quests
 
-| ID | Triggering tool call | Validator |
+| ID | Triggering tool | Validator reads from `quest_metadata` |
 |---|---|---|
-| `swap` | `build_swap_tx` broadcast | min `amount_usd` (e.g. ≥ $10), allow-listed router contracts |
-| `bridge` | `build_bridge_tx` broadcast | source chain ≠ dest chain, min `amount_usd` |
-| `defi_action` | `build_evm_tx` broadcast targeting an allow-listed contract | contract address in `DEFI_ACTION_CONTRACT_ALLOWLIST` |
+| `swap` | `build_swap_tx` | `amount_usd >= SWAP_QUEST_MIN_USD`, `token_in_symbol != token_out_symbol`, `router_address` present |
+| `bridge` | `build_swap_tx` (cross-chain), or a future `build_bridge_tx` | `amount_usd >= BRIDGE_QUEST_MIN_USD`, `source_chain_id != dest_chain_id` |
+| `defi_action` | `build_evm_tx` | `target_contract` in `DEFI_ACTION_CONTRACT_ALLOWLIST` |
 | `alert` | (TBD with Product) | (TBD) |
 | `dca` | (TBD with Product) | (TBD) |
 
-The first three are well-defined; `alert` and `dca` are pending Product lock per the Stage 0 decisions table. The validator code for those two ships as stubs that always return "not counting" until the rules are filled in. The hook dispatch in `tool-result` is generic (switches on quest_id), so wiring the stubs in later is a one-file change with no architectural impact.
+The first three are well-defined; `alert` and `dca` are pending Product lock per the Stage 0 decisions table. The validator code for those two ships as stubs that return "not counting" until the rules are filled in. The dispatch table (`tool_name` → `quest_type`) is generic, so adding a new quest is a one-file change with no architectural impact.
 
 3-of-5 is the threshold. This is `QUEST_THRESHOLD = 3` in config — could move if Product changes their mind.
+
+---
+
+## Cross-team contract — the `quest_metadata` shape
+
+The hook depends on two new columns on `agent_tx_proposals`, populated by the agent-backend at proposal-creation time. Without these columns, this stage cannot ship.
+
+```sql
+ALTER TABLE agent_tx_proposals ADD COLUMN tool_name TEXT;        -- e.g. "build_swap_tx"
+ALTER TABLE agent_tx_proposals ADD COLUMN quest_metadata JSONB;  -- normalised, see below
+```
+
+`quest_metadata` schema — flat JSON object, all fields optional, validators only read what they need:
+
+```json
+{
+  "amount_usd":         25.50,
+  "token_in_symbol":    "USDC",
+  "token_out_symbol":   "ETH",
+  "source_chain_id":    1,
+  "dest_chain_id":      1,
+  "target_contract":    "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+  "router_address":     "0x6131b5fae19ea4f9d964eac0408e4408b66337b5"
+}
+```
+
+Notes:
+- `amount_usd` is a JSON number (decimal, not an integer in cents). For swap/bridge it's the USD value of the user-side amount, computed by whichever tool built the tx using its existing quote pipeline.
+- Chain IDs are **integers** (1, 42161, 8453, …), not strings. This is a deliberate divergence from the existing `tx_proposals.chain` column (which holds strings like "ethereum"). Integers are the universal EVM convention; the validators do `source_chain_id != dest_chain_id` cleanly without string-normalisation.
+- Addresses are lowercase hex with `0x` prefix. The DeFi-action validator does a lowercase compare against the configured allowlist.
+- For tools that don't compute USD value (e.g. native sends with no quote), `amount_usd` is omitted. The validators treat absence as "below threshold" and reject the event.
+
+**Three-team responsibility split:**
+
+| Layer | Responsibility |
+|---|---|
+| **MCP team** (`vultisig/mcp` repo) | Each `build_*` tool emits a `quest_metadata` block in its result, populated from the data it already has during quote/build. **Sized:** `build_evm_tx` ~5 lines (chain ID + target_contract are already in the result struct, just expose). `build_swap_tx` ~25 lines (need to call the existing `coingecko.Client` to compute `amount_usd` from the user's input amount + fetched USD price; `bundle.Quote.Router` exists internally but isn't currently exposed in the result struct, so add `RouterAddress`). No new external dependency — CoinGecko client is already wired up in MCP. |
+| **agent-backend team** | Migration to add `tool_name` + `quest_metadata` columns. In `internal/service/scheduler/scheduler.go` (call site of `txProposalRepo.Create`; grep for it — currently around line 320, may drift), capture `tool.Name` from the active `result.ToolLogs` entry and forward `tool.Result.quest_metadata` to the new columns. ~10 lines of Go + 1 migration. |
+| **Airdrop module (this stage)** | Read the populated columns at quest-event time. Trivial dispatch + validators. |
+
+Stage 0's decisions table tracks the cross-team commit on this schema (row 12).
 
 ---
 
@@ -32,7 +75,7 @@ The first three are well-defined; `alert` and `dca` are pending Product lock per
 
 All quest endpoints are **internal** — paths under `/internal/quests/...`. Every request must carry `X-Internal-Token: <secret>` matching the `INTERNAL_API_KEY` env var. No JWT, no public exposure. Middleware rejects anything missing or wrong with `401 Unauthorized`.
 
-The agent runtime (in this same binary) injects the header on internal calls. If/when other services need to fire quest events, they read the same secret from a shared store.
+The agent-backend's `SignTxProposal` handler injects the header on its in-process call to `/internal/quests/event`. If/when other services need to fire quest events, they read the same secret from a shared store.
 
 ---
 
@@ -42,7 +85,7 @@ This stage exposes only one endpoint — the quest event ingester. Eligibility i
 
 ### `POST /internal/quests/event`
 
-**Purpose:** record a single quest-relevant action. Called from the `POST /conversations/{id}/tool-result` handler (in this binary) after the mobile app reports that a tool call's transaction was signed and broadcast.
+**Purpose:** record a single quest-relevant action. Called from the existing `SignTxProposal` handler in this binary after the mobile app reports that a tool-built transaction was signed and broadcast. The hook reads `proposal.tool_name` and `proposal.quest_metadata` from the now-marked-signed row and forwards the values here.
 
 **Request:**
 ```http
@@ -51,53 +94,47 @@ X-Internal-Token: <secret>
 Content-Type: application/json
 
 {
-  "public_key": "...",
-  "quest_type": "swap" | "bridge" | "defi_action" | "alert" | "dca",
-  "tool_call_id": "...",
-  "tx_hash": "0x...",
-  "data": { /* quest-type-specific fields, see below */ }
+  "public_key":     "...",
+  "tool_call_id":   "...",          // proposal_id is fine — same idempotency property
+  "tx_hash":        "0x...",
+  "tool_name":      "build_swap_tx",
+  "quest_metadata": { /* the agent-backend's persisted blob, forwarded as-is */ }
 }
 ```
 
-`tool_call_id` is the idempotency key — if the same tool result is reported twice, the second call is a no-op (returns 200 with the existing event row). `tx_hash` is captured for audit (lets ops verify a quest event by inspecting the chain).
+The handler dispatches `tool_name` → `quest_type` via a 5-line lookup table. If the tool has no quest mapping (e.g. `build_observe_tx`), the handler returns 200 with `recorded: false` — not an error.
 
-Per-quest `data` payloads:
-
-| Quest | `data` shape |
-|---|---|
-| `swap` | `{ amount_usd, token_in, token_out, chain_id, router_address }` |
-| `bridge` | `{ amount_usd, source_chain_id, dest_chain_id }` |
-| `defi_action` | `{ contract_address, chain_id, method }` |
-| `alert` | TBD |
-| `dca` | TBD |
+`tool_call_id` is the idempotency key — if the same proposal is signed-and-reported twice, the second call is a no-op. In practice the proposal's UUID is fine here. `tx_hash` is captured for audit.
 
 **Response — 200:**
 ```json
 { "recorded": true, "quest_completed": false, "quests_completed": 2 }
 ```
 
-`recorded` is true for both fresh inserts and idempotent retries. `quest_completed` is true only when this event is the one that flipped the user's `user_quests` row to complete (i.e. the first qualifying event for that quest). `quests_completed` is the user's running count (used by callers for logging or UX hints).
+`recorded` is true if the event was inserted (fresh OR idempotent retry). `quest_completed` is true only when this event is the one that flipped the user's `user_quests` row to complete. `quests_completed` is the user's running count.
+
+If `tool_name` has no mapping, returns `{ "recorded": false }` with no quest event written.
 
 **Errors:**
 
 | Status | Body | When |
 |---|---|---|
 | 401 | `{"error":"UNAUTHORIZED"}` | Missing or wrong `X-Internal-Token` |
-| 400 | `{"error":"INVALID_QUEST_TYPE"}` | `quest_type` not in enum |
-| 400 | `{"error":"INVALID_PAYLOAD"}` | `data` doesn't match the quest's expected shape |
+| 400 | `{"error":"MISSING_FIELDS"}` | `public_key` / `tool_name` / `tool_call_id` missing |
 | 403 | `{"error":"QUEST_NOT_ACTIVE"}` | `now() < QUEST_ACTIVATION_TIMESTAMP` |
 
 **Behavior:**
 
-1. Validate envelope (`quest_type`, `tool_call_id`, `tx_hash`).
+1. Validate envelope (`public_key`, `tool_name`, `tool_call_id`, `tx_hash`).
 2. Reject if `now() < QUEST_ACTIVATION_TIMESTAMP` (Day 13).
-3. Dispatch to the per-quest validator (one Go file per quest type). Validator returns `{ qualifies: bool, reason: string }`.
-4. If `qualifies == false`: insert a `quest_events` row with `status='rejected'` and the reason. Return 200 with `recorded: true, quest_completed: false`. (Logging the rejection helps Product see why borderline events didn't count.)
-5. If `qualifies == true`:
+3. Look up `tool_name` in the dispatch table. If unmapped, return 200 with `recorded: false`.
+4. Dispatch to the per-quest validator. Validator returns `{ qualifies: bool, reason: string }`.
+5. If `qualifies == false`: insert a `quest_events` row with `counted=false` and the reason. Return 200 with `recorded: true, quest_completed: false`. (Logging the rejection helps Product see why borderline events didn't count.)
+6. If `qualifies == true`:
    - `INSERT INTO agent_quest_events ... ON CONFLICT (tool_call_id) DO NOTHING` (idempotent).
    - `INSERT INTO agent_user_quests (public_key, quest_id) VALUES (...) ON CONFLICT DO NOTHING RETURNING xmax = 0 AS was_inserted` to mark the quest complete (no-op if already complete).
    - Read the user's current `quests_completed`.
-6. Return 200 with the result fields.
+7. Return 200 with the result fields.
 
 ## Eligibility check
 
@@ -117,14 +154,25 @@ This composite is also what Stage 1's `/airdrop/status` returns as the `claim_el
 
 ## Wiring the runtime hook
 
-In the existing `POST /conversations/{id}/tool-result` handler (Stage 4 of the chat lifecycle, not Stage 4 of this spec — different "Stage 4"), after the existing logic stores the tool result as conversation metadata, add:
+The hook lives in agent-backend's existing `SignTxProposal` handler (`internal/api/tx_proposals.go:95-117`). After the existing `MarkSigned` call succeeds, add:
 
-1. Inspect the incoming `{toolCallId, name, result}`.
-2. If `name` matches a quest-relevant tool (`build_swap_tx`, `build_bridge_tx`, `build_evm_tx`, etc.) AND `result` indicates a successful broadcast (looking at the tool result schema — likely a `tx_hash` field), translate to a quest event.
-3. POST to `/internal/quests/event` (in-process, but over HTTP per the API-endpoint pattern — uses the `INTERNAL_API_KEY` from config).
-4. Errors from `/internal/quests/event` are logged but do not propagate to the handler's response. Quest tracking is best-effort — if it fails, the user can re-trigger by repeating the action; ops audits via the `quest_events` table.
+1. Re-read the proposal (or pass `proposal.ToolName` + `proposal.QuestMetadata` through `MarkSigned`'s return — implementer's choice).
+2. If `tool_name` is empty (proposal predates the migration, or a tool that doesn't tag itself), skip — no quest event fires.
+3. Build the request body: `{ public_key, tool_call_id: proposal.ID, tx_hash: req.TxHash, tool_name, quest_metadata }`.
+4. POST to `http://localhost:<server-port>/internal/quests/event` with `X-Internal-Token: <INTERNAL_API_KEY>`.
+5. Errors are logged but **do not propagate** to the user's `/sign` response. Quest tracking is best-effort — a failed quest hook doesn't fail the user's sign action. If the quest event was lost, the user can re-trigger by repeating the action; ops audits via the `quest_events` table and the `agent_tx_proposals` row's `quest_metadata` field.
 
-The map from tool name → quest type lives in one Go file (`quest_dispatch.go`). Adding or renaming a triggering tool is a one-line change there.
+The `tool_name → quest_type` map lives in one Go file (`internal/service/airdrop/quests/dispatch.go`):
+
+```go
+var toolToQuest = map[string]string{
+    "build_swap_tx":   "swap",   // or "bridge" — depends on source_chain_id == dest_chain_id; resolved by the validator dispatch
+    "build_bridge_tx": "bridge",
+    "build_evm_tx":    "defi_action",
+}
+```
+
+For `build_swap_tx` specifically, the dispatch needs to inspect `quest_metadata.source_chain_id` vs `dest_chain_id` to decide swap vs bridge — same tool, different quest depending on whether the chains differ. One small switch in the dispatch.
 
 ---
 
@@ -132,17 +180,16 @@ The map from tool name → quest type lives in one Go file (`quest_dispatch.go`)
 
 ```sql
 CREATE TYPE airdrop_quest_id AS ENUM ('swap', 'bridge', 'defi_action', 'alert', 'dca');
-CREATE TYPE airdrop_quest_event_status AS ENUM ('counted', 'rejected');
 
 CREATE TABLE agent_quest_events (
-    tool_call_id  TEXT                          PRIMARY KEY,           -- idempotency key
-    public_key    TEXT                          NOT NULL,
-    quest_id      airdrop_quest_id              NOT NULL,
-    tx_hash       TEXT                          NOT NULL,
-    status        airdrop_quest_event_status    NOT NULL,
-    reject_reason TEXT,                                                -- non-null only when status='rejected'
-    payload       JSONB                         NOT NULL,
-    created_at    TIMESTAMPTZ                   NOT NULL DEFAULT NOW()
+    tool_call_id    TEXT             PRIMARY KEY,                       -- idempotency key (in practice, the proposal UUID)
+    public_key      TEXT             NOT NULL,
+    quest_id        airdrop_quest_id NOT NULL,
+    tx_hash         TEXT             NOT NULL,
+    counted         BOOLEAN          NOT NULL,                          -- true if the validator qualified this event
+    reject_reason   TEXT,                                               -- non-null only when counted = false
+    tx_proposal_id  UUID,                                               -- soft reference to agent_tx_proposals(id) for audit. No FK — keeps migrations independent and tolerates proposal cleanup.
+    created_at      TIMESTAMPTZ      NOT NULL DEFAULT NOW()
 );
 
 CREATE INDEX idx_quest_events_public_key ON agent_quest_events (public_key);
@@ -155,11 +202,13 @@ CREATE TABLE agent_user_quests (
 );
 ```
 
-Two tables. `quest_events` is the append-only audit log (one row per incoming event, including rejected ones). `user_quests` is the materialised "which quests has each user completed" view (one row per user-quest combination, exists ⇔ quest is complete).
+Two tables. `quest_events` is the append-only audit log (one row per incoming event, including rejected ones). `user_quests` is the materialised "which quests has each user completed" view.
 
-`tool_call_id` as the events PK gives free idempotency at the database layer. `(public_key, quest_id)` as the user_quests PK gives free deduplication ("a quest is either complete or not, two qualifying events for the same quest = one row").
+`tool_call_id` as the events PK gives free idempotency at the database layer. `(public_key, quest_id)` as the user_quests PK gives free deduplication.
 
-`quests_completed` for a user is `SELECT COUNT(*) FROM agent_user_quests WHERE public_key = ?` — fast PK lookup, no separate counter to keep in sync.
+`quests_completed` for a user is `SELECT COUNT(*) FROM agent_user_quests WHERE public_key = ?` — fast PK lookup, no separate counter.
+
+The `tool_name` + `quest_metadata` columns on `agent_tx_proposals` are owned by the agent-backend team (see Cross-team contract above), not this stage's migration set.
 
 ---
 
@@ -170,7 +219,7 @@ Two tables. `quest_events` is the append-only audit log (one row per incoming ev
 | `INTERNAL_API_KEY` | string secret | Shared secret for `X-Internal-Token` on `/internal/*` endpoints |
 | `QUEST_ACTIVATION_TIMESTAMP` | RFC3339 timestamp | Day 13 wall clock — events before this are rejected |
 | `QUEST_THRESHOLD` | int, default 3 | How many of 5 quests are needed to be claim-eligible |
-| `DEFI_ACTION_CONTRACT_ALLOWLIST` | comma-separated 0x-addresses | Allow-list for the `defi_action` quest validator |
+| `DEFI_ACTION_CONTRACT_ALLOWLIST` | comma-separated 0x-addresses | Allow-list for the `defi_action` quest validator. Lowercased at parse time. |
 | `SWAP_QUEST_MIN_USD` | int, default 10 | Min USD value for a swap to count |
 | `BRIDGE_QUEST_MIN_USD` | int, default 10 | Min USD value for a bridge to count |
 
@@ -182,20 +231,21 @@ Prometheus metrics:
 
 | Metric | Type | Labels |
 |---|---|---|
-| `airdrop_quest_event_total` | Counter | `quest_type`, `result` ∈ `{counted, rejected, idempotent_retry}` |
+| `airdrop_quest_event_total` | Counter | `quest_type`, `result` ∈ `{counted, rejected, idempotent_retry, unmapped_tool}` |
 | `airdrop_quest_event_reject_reason_total` | Counter | `quest_type`, `reason` |
 | `airdrop_quest_completion_total` | Counter | `quest_type` (incremented when a quest first flips to complete for a user) |
 
-Structured logs include `public_key` (first 8 chars), `quest_type`, `tool_call_id`, `tx_hash`, `result`, `request_id`.
+Structured logs include `public_key` (first 8 chars), `tool_name`, `quest_type`, `tool_call_id`, `tx_hash`, `result`, `request_id`.
 
 ---
 
 ## Tests
 
 **Unit (per quest validator):**
-- Boundary cases: just-below threshold, just-above, exact match.
-- Negative cases: wrong chain, contract not on allowlist, missing required fields.
+- Boundary cases: just-below threshold, just-above, exact match — using `quest_metadata` fixtures.
+- Negative cases: missing `amount_usd` → rejected, contract not on allowlist → rejected, swap with same chain ID and same token → rejected.
 - Idempotency: same `tool_call_id` twice yields one row, both responses are 200.
+- Unmapped `tool_name`: returns 200 with `recorded: false`, no DB write.
 
 **Unit (eligibility helper):**
 - Won raffle + 3 quests + not claimed → eligible.
@@ -204,7 +254,7 @@ Structured logs include `public_key` (first 8 chars), `quest_type`, `tool_call_i
 - Won raffle + 3 quests + already claimed → not eligible.
 
 **Integration (real Postgres):**
-- Full path: tool-result handler receives synthetic broadcast notification → quest event recorded → `quests_completed` increments → eligibility check flips to true at 3rd completion.
+- Full path: synthetic `agent_tx_proposals` row with `tool_name` + `quest_metadata` populated → call `SignTxProposal` → quest event recorded → `quests_completed` increments → eligibility check flips to true at 3rd completion.
 - Activation timestamp gate: pre-activation event is rejected; post-activation is counted.
 
 ---
@@ -215,25 +265,22 @@ Structured logs include `public_key` (first 8 chars), `quest_type`, `tool_call_i
 internal/api/airdrop/
 └── quests_event.go      POST /internal/quests/event handler
 
-internal/api/middleware/
-└── internal_token.go    Shared-secret check for /internal/* paths
-
 internal/service/airdrop/quests/
-├── dispatch.go          Map quest_type → validator; called by event handler
+├── dispatch.go          Map tool_name → quest_type (handles swap-vs-bridge by chain ID)
 ├── validators/
-│   ├── swap.go          Hard-coded swap validator
-│   ├── bridge.go        Hard-coded bridge validator
-│   ├── defi_action.go   Hard-coded DeFi action validator
+│   ├── swap.go          Reads quest_metadata.amount_usd, token symbols, router_address
+│   ├── bridge.go        Reads quest_metadata.amount_usd, source/dest chain IDs
+│   ├── defi_action.go   Reads quest_metadata.target_contract; checks allowlist
 │   ├── alert.go         Stub until Product locks
 │   └── dca.go           Stub until Product locks
-└── eligibility.go       Computes claim_eligible from raffle_winners + user_quests + claim_submissions; called by Stage 1 status + Stage 4 claim
+└── eligibility.go       Owned by Stage 1's plan (Stage 1 is first consumer); Stage 4 reuses
 
-internal/service/agent/conversations/
-└── tool_result.go       (edit) — wire the quest hook after the existing tool-result storage logic; map tool name → quest_type via quest_dispatch.go
+internal/api/
+└── tx_proposals.go      (edit) — add the quest hook to SignTxProposal after MarkSigned succeeds
 
 internal/storage/postgres/
-├── migrations/XXXXXXXXXXXXXX_create_agent_quest_events.sql
-├── migrations/XXXXXXXXXXXXXX_create_agent_user_quests.sql
+├── migrations/XXXXXXXXXXXXXX_create_agent_quest_events.sql   (shipped by shared-infra plan)
+├── migrations/XXXXXXXXXXXXXX_create_agent_user_quests.sql    (shipped by shared-infra plan)
 └── sqlc/airdrop_quests.sql
 ```
 
@@ -241,9 +288,12 @@ internal/storage/postgres/
 
 ## Open dependencies
 
+- **MCP team — `quest_metadata` block emitted by `build_swap_tx`, `build_evm_tx`, and any bridge-equivalent tool.** Lock the schema (see "Cross-team contract" above) and ship before this stage can be E2E-tested. **Hard blocker.**
+- **agent-backend team — migration adding `tool_name` + `quest_metadata` to `agent_tx_proposals`, plus the ~10-line scheduler.go change to populate them at proposal-creation time.** **Hard blocker.**
 - **Stage 0 — `INTERNAL_API_KEY` chosen + injected into the deploy.**
 - **Stage 0 — `QUEST_ACTIVATION_TIMESTAMP`, `DEFI_ACTION_CONTRACT_ALLOWLIST` decisions locked.**
 - **Stage 0 — final 5-quest list locked by Product** (specifically the `alert` and `dca` validators).
+- **Stage 0 — `quest_metadata` schema lock signed off** by MCP team + agent-backend team + airdrop eng (decisions row 12).
 - **Stage 1 — status endpoint extension** to include quest fields and `claim_eligible` (done — see Stage 1 spec).
 - **Stage 4 — relayer calls `eligibility.go` directly in-process** (it's a shared helper, not an HTTP boundary).
 
@@ -252,9 +302,10 @@ internal/storage/postgres/
 ## Done when
 
 - The event endpoint responds with documented shapes against documented status codes.
-- Three live quest validators (swap, bridge, defi_action) implemented and unit-tested for boundary cases.
+- Three live quest validators (swap, bridge, defi_action) implemented and unit-tested for boundary cases against `quest_metadata` fixtures.
 - Stub validators (alert, dca) in place returning "not counting" until Product locks.
 - Idempotency: duplicate `tool_call_id` POSTs result in one event row, both 200 responses.
 - Activation gate: events pre-activation are rejected; post-activation are counted.
 - Eligibility helper returns the correct boolean for all combinations of (won, quests_completed, already_claimed).
-- Tool-result hook in the conversations handler fires `/internal/quests/event` correctly; failures are logged but not propagated.
+- Hook in `SignTxProposal` fires `/internal/quests/event` correctly; failures are logged but not propagated.
+- E2E confirmation: at least one real `build_swap_tx` flow in staging produces a populated `quest_metadata` block and a `counted` quest event row.

--- a/docs/airdrop-specs/stage-4-claim-relayer.md
+++ b/docs/airdrop-specs/stage-4-claim-relayer.md
@@ -31,8 +31,9 @@ Concurrency model: claim handlers serialize through `SELECT FOR UPDATE` on the r
 | Surface | Auth |
 |---|---|
 | `POST /airdrop/claim` | JWT (existing middleware) |
-| `GET /internal/relayer/*` | `X-Internal-Token` header (same secret as quest endpoints) |
 | `GET /ops/*`, `POST /ops/*` | HTTP Basic Auth via `OPS_USERNAME` + `OPS_PASSWORD` env vars |
+
+There are no `/internal/relayer/*` routes. The balance + stuck-claims views are served directly from `/ops/balance` and `/ops/stuck-claims` over Basic Auth — same logic, half the surface, one less auth mechanism.
 
 ---
 
@@ -81,7 +82,7 @@ Empty body. Public key from JWT, recipient + amount from `agent_raffle_winners` 
 | 403 | `{"error":"CLAIM_DISABLED"}` | `CLAIM_ENABLED == false` (operator kill switch) |
 | 503 | `{"error":"RPC_UNAVAILABLE"}` | EVM RPC didn't respond or returned a non-revert error |
 | 503 | `{"error":"KMS_UNAVAILABLE"}` | KMS Sign API failed (relayer wallet signing) |
-| 500 | `{"error":"BROADCAST_REJECTED","detail":"..."}` | RPC accepted the tx but returned a logical error (e.g. nonce already used, insufficient funds) — relayer state may need ops attention |
+| 503 | `{"error":"BROADCAST_REJECTED","detail":"..."}` | RPC accepted the tx but returned a logical error (e.g. nonce already used, insufficient funds). Relayer state may need ops attention; logged at warn for ops dashboards. |
 
 503 errors are transient — client retries.
 
@@ -97,7 +98,7 @@ Empty body. Public key from JWT, recipient + amount from `agent_raffle_winners` 
 8. `next_nonce = relayer_state.next_nonce`.
 9. Fetch `(recipient, amount)` from `agent_raffle_winners WHERE public_key = ?`. (No proof — the contract's allowance mapping is the source of truth on-chain.)
 10. Query EVM RPC for current gas estimates: `eth_maxPriorityFeePerGas` for tip, latest block's `baseFeePerGas` for the base. `maxFeePerGas = 2 * baseFee + tip` (standard padded formula).
-11. Build the calldata for `AirdropClaim.claim(recipient)`. Exact ABI from `mergecontract`. The `amount` is already locked in the contract's allowance; we record it locally only for display in the status response.
+11. Build the calldata for `AirdropClaim.claim(recipient)`. Exact ABI from `vultisig-contract`. The `amount` is already locked in the contract's allowance; we record it locally only for display in the status response.
 12. Build EIP-1559 tx with `next_nonce`, gas params from step 10, calldata, chain ID from `EVM_CHAIN_ID`.
 13. Sign the tx via AWS KMS `Sign` with `KMS_RELAYER_KEY_ARN`. Convert returned DER signature to EVM `(r, s, v)` and assemble the signed tx bytes.
 14. Broadcast via RPC (`eth_sendRawTransaction`).
@@ -110,61 +111,7 @@ If any of steps 9–14 fail, ROLLBACK. The state row's `next_nonce` is unchanged
 
 The eligibility check in step 4 calls the shared `eligibility.go` helper from Stage 3 (in-process Go function call, not an HTTP roundtrip — eligibility is a pure DB read with no signing or external calls, so the API-endpoint pattern doesn't apply).
 
-### `GET /internal/relayer/balance`
-
-**Purpose:** ops health check + alert source.
-
-**Request:** `X-Internal-Token: <secret>`.
-
-**Response — 200:**
-```json
-{
-  "relayer_address": "0x...",
-  "eth_balance_wei": "5000000000000000000",
-  "eth_balance_human": "5.000",
-  "vult_contract_balance_wei": "1417500000000000000000000",
-  "vult_contract_balance_human": "1417500.000",
-  "low_balance_warning": false,
-  "low_balance_threshold_eth": "0.5",
-  "estimated_claims_remaining": 1234,
-  "next_nonce": 42,
-  "rpc_block_height": 19400000
-}
-```
-
-`estimated_claims_remaining = floor(eth_balance / (avg_gas_per_claim * current_gas_price))`. Read live from RPC.
-
-`low_balance_warning = true` when `eth_balance < LOW_BALANCE_THRESHOLD_ETH` (env, default 0.5 ETH).
-
-### `GET /internal/relayer/stuck-claims`
-
-**Purpose:** list submitted-but-unconfirmed claims older than a configurable threshold so ops can decide whether to rebroadcast.
-
-**Request:** `X-Internal-Token: <secret>`. Optional query param `?older_than_minutes=N` (default 10).
-
-**Response — 200:**
-```json
-{
-  "stuck_claims": [
-    {
-      "public_key": "...",
-      "tx_hash": "0x...",
-      "nonce": 17,
-      "submitted_at": "2026-05-15T17:00:00Z",
-      "minutes_pending": 23,
-      "max_fee_gwei": 50,
-      "max_priority_fee_gwei": 2,
-      "previous_tx_hashes": ["0x...prior...", "..."]
-    },
-    ...
-  ],
-  "count": 5
-}
-```
-
-Sorted by `minutes_pending` descending. Empty array (count: 0) is the healthy state.
-
-Rebroadcast lives on the operator UI surface only — see `POST /ops/rebroadcast` below. There's no separate `/internal/relayer/rebroadcast` endpoint; one form handler over Basic Auth covers both browser ops and curl-from-script use.
+There is no `/internal/relayer/*` route group. Balance and stuck-claims health are served directly from `/ops/balance` and `/ops/stuck-claims` (Basic Auth). The data shapes are documented in the Operator interface section below.
 
 ---
 
@@ -175,11 +122,11 @@ Server-rendered HTML pages using Go's `html/template`. No JS build, no client-si
 | Path | Page |
 |---|---|
 | `GET /ops` | Landing page. Links to balance, stuck-claims. Shows last-refreshed time. |
-| `GET /ops/balance` | Renders the JSON output of `/internal/relayer/balance` as a styled table. Auto-refreshes every 30s via `<meta http-equiv="refresh">`. Big red banner if `low_balance_warning`. |
-| `GET /ops/stuck-claims` | Table of `/internal/relayer/stuck-claims` output. Each row has a "Rebroadcast (+50 gwei)" button. |
-| `POST /ops/rebroadcast` | Form handler. Reads `{public_key, bump_gwei}` (default 50). Calls the rebroadcast service in-process: sign new EIP-1559 tx with **same nonce** + bumped fees, broadcast, append previous `tx_hash` to `previous_tx_hashes`, update `tx_hash` + gas fields. Returns 404 if no row, 400 if already confirmed, 503 if RPC failed. Renders a success/error page with the new tx hash + Etherscan link. The old tx and new tx race in the mempool — both share the same nonce so only one can confirm. |
+| `GET /ops/balance` | Renders relayer health as a styled table. Auto-refreshes every 30s via `<meta http-equiv="refresh">`. Big red banner if `low_balance_warning`. Shape: `relayer_address`, `eth_balance_wei`/`_human`, `vult_contract_balance_wei`/`_human`, `low_balance_warning`, `low_balance_threshold_eth`, `estimated_claims_remaining`, `next_nonce`, `rpc_block_height`. `estimated_claims_remaining = floor(eth_balance / (avg_gas_per_claim * current_gas_price))`. `low_balance_warning = true` when `eth_balance < LOW_BALANCE_THRESHOLD_ETH`. |
+| `GET /ops/stuck-claims` | Table of submitted-but-unconfirmed claims older than `?older_than_minutes=N` (default 10), sorted by minutes-pending descending. Each row shows `public_key` (first 8), `tx_hash` (linked to Etherscan), `nonce`, `submitted_at`, `minutes_pending`, `max_fee_gwei`, `max_priority_fee_gwei`. Each row has a "Rebroadcast (+50 gwei)" button. Empty table is the healthy state. |
+| `POST /ops/rebroadcast` | Form handler. Reads `{public_key, bump_gwei}` (default 50). Calls the rebroadcast service in-process: sign new EIP-1559 tx with **same nonce** + bumped fees, broadcast, update `tx_hash` + gas fields on the row. Returns 404 if no row, 400 if already confirmed, 503 if RPC failed. Renders a success/error page with the new tx hash + Etherscan link. The old tx and new tx race in the mempool — both share the same nonce so only one can confirm. |
 
-The two `GET` ops pages call the matching `/internal/*` endpoints in-process (with the same `X-Internal-Token` from config). The rebroadcast page calls the rebroadcast service directly — no internal HTTP roundtrip.
+Pages query the DB + RPC directly via the relayer service — no internal HTTP roundtrip.
 
 Templates in `internal/api/ops/templates/`. CSS inlined into `<style>` blocks (no separate static asset pipeline). One Go file per route.
 
@@ -214,8 +161,7 @@ CREATE TABLE agent_claim_submissions (
     nonce                 BIGINT                 NOT NULL UNIQUE,                 -- one nonce, one row, ever
     recipient             TEXT                   NOT NULL,
     amount                NUMERIC(78, 0)         NOT NULL,
-    tx_hash               TEXT                   NOT NULL,
-    previous_tx_hashes    TEXT[]                 NOT NULL DEFAULT '{}',           -- preserved when rebroadcast
+    tx_hash               TEXT                   NOT NULL,                          -- updated in place on rebroadcast
     status                airdrop_claim_status   NOT NULL,
     max_fee_gwei          INTEGER                NOT NULL,
     max_priority_fee_gwei INTEGER                NOT NULL,
@@ -248,7 +194,9 @@ INSERT INTO agent_relayer_state (id) VALUES (1);                                
 
 On service boot, if `next_nonce` is NULL the relayer queries `eth_getTransactionCount(relayer_address, 'pending')` and writes the result inside a `SELECT FOR UPDATE` transaction. Subsequent boots no-op. Removes the manual `psql UPDATE` that would otherwise be a Day 28 footgun.
 
-`previous_tx_hashes` preserves the audit trail across rebroadcasts. `nonce UNIQUE` is the database-level guard against accidental nonce reuse (anywhere — across all users). The partial unique index on `(public_key)` enforces the "one claim per user" invariant. The `(submitted_at) WHERE status='submitted'` partial index makes the monitor's scan O(unconfirmed) rather than O(all_claims).
+`nonce UNIQUE` is the database-level guard against accidental nonce reuse (anywhere — across all users). The partial unique index on `(public_key)` enforces the "one claim per user" invariant. The `(submitted_at) WHERE status='submitted'` partial index makes the monitor's scan O(unconfirmed) rather than O(all_claims).
+
+Rebroadcasts update `tx_hash` in place. Audit trail of prior bumps lives in the structured logs (one log line per rebroadcast tagged with old `tx_hash`, new `tx_hash`, bump amount, operator). Etherscan covers the public chain side. The previous-array column was dropped 2026-04-23 — ops debug from logs instead.
 
 ---
 
@@ -262,7 +210,7 @@ On service boot, if `next_nonce` is NULL the relayer queries `eth_getTransaction
 | `AIRDROP_CLAIM_CONTRACT_ADDRESS` | 0x-address | Same value as Stage 3's `verifyingContract`. |
 | `CLAIM_WINDOW_OPEN_AT` | RFC3339 timestamp | Day 28 wall clock; before this, `/airdrop/claim` returns 403. |
 | `CLAIM_ENABLED` | bool, default true | Operator kill switch. Read on every request — hot-reload by env-var change + service signal, or a redeploy. |
-| `LOW_BALANCE_THRESHOLD_ETH` | decimal, default 0.5 | Triggers `low_balance_warning: true` in `/internal/relayer/balance`. |
+| `LOW_BALANCE_THRESHOLD_ETH` | decimal, default 0.5 | Triggers `low_balance_warning: true` in `/ops/balance`. |
 | `CONFIRMATION_BLOCKS` | int, default 1 | Required reorg depth before marking a tx `confirmed`. |
 | `CONFIRMATION_POLL_INTERVAL_SECONDS` | int, default 15 | How often the monitor checks for receipts. |
 | `OPS_USERNAME` / `OPS_PASSWORD` | strings | HTTP Basic Auth credentials for the operator UI. |
@@ -299,7 +247,7 @@ A Prometheus alert on `airdrop_relayer_eth_balance_wei < 0.5e18` pages ops.
 - Window enforcement: before, exactly at, after `CLAIM_WINDOW_OPEN_AT`.
 - Kill switch: `CLAIM_ENABLED=false` returns `403 CLAIM_DISABLED`.
 - Idempotency: two concurrent calls (simulated via mock `FOR UPDATE` serialization) — one inserts, the other returns the inserted row's `tx_hash`.
-- Rebroadcast: existing row is updated, `previous_tx_hashes` is appended, nonce unchanged.
+- Rebroadcast: existing row is updated in place (new `tx_hash`, bumped fees), nonce unchanged.
 - KMS DER → EVM signature: golden test against a known-good signature.
 
 **Integration (real Postgres + LocalStack KMS + Anvil mainnet fork):**
@@ -307,10 +255,10 @@ A Prometheus alert on `airdrop_relayer_eth_balance_wei < 0.5e18` pages ops.
 - Restart-safety: kill the service after the broadcast UPDATE but before… (well, the broadcast and UPDATE are in one txn, so there's no in-between state). Test instead: kill the service immediately after broadcast (one tx in `submitted` state in DB), restart, observe monitor pick up the submitted row on its first tick and confirm against Anvil.
 - Concurrency: 50 concurrent /airdrop/claim calls for 50 distinct eligible users → 50 distinct nonces, 50 distinct tx hashes, no DB constraint violations, all submitted within ~50 seconds.
 - Concurrency: 50 concurrent /airdrop/claim calls for the same user → exactly one tx submitted, 49 idempotent-retry responses with the same tx_hash.
-- Stuck-tx flow: tx broadcast at low gas → never confirms → `/internal/relayer/stuck-claims` lists it → `POST /ops/rebroadcast` form with bump → new tx confirms → original is dropped (same nonce).
+- Stuck-tx flow: tx broadcast at low gas → never confirms → `/ops/stuck-claims` lists it → `POST /ops/rebroadcast` form with bump → new tx confirms → original is dropped (same nonce).
 - Balance endpoint returns expected values; low-balance threshold flips the warning.
 
-**End-to-end (with `mergecontract`):**
+**End-to-end (with `vultisig-contract`):**
 - Multisig calls `setWinners` on Foundry-deployed `AirdropClaim.sol` → claim submitted by Stage 4's relayer against the same contract → contract pays VULT to recipient.
 
 ---
@@ -324,10 +272,6 @@ cmd/scheduler/
 internal/api/airdrop/
 └── claim.go              POST /airdrop/claim handler
 
-internal/api/relayer/
-├── balance.go            GET /internal/relayer/balance
-└── stuck_claims.go       GET /internal/relayer/stuck-claims
-
 internal/api/ops/
 ├── handler.go            Routing + inline Basic Auth check (5-line stdlib helper, no shared middleware)
 ├── templates/
@@ -335,7 +279,7 @@ internal/api/ops/
 │   ├── balance.html
 │   ├── stuck_claims.html
 │   └── rebroadcast_result.html
-└── ops.go                One file per page wiring data → template; rebroadcast page calls relayer/rebroadcast.go directly
+└── ops.go                One file per page wiring data → template; balance and stuck-claims pages call the relayer service directly; rebroadcast page calls relayer/rebroadcast.go directly
 
 internal/service/airdrop/relayer/
 ├── claim.go              Top-level claim flow (validation → tx build → broadcast → DB). Calls eligibility helper from internal/service/airdrop/quests/eligibility.go
@@ -363,7 +307,7 @@ docs/runbooks/
 - **Stage 0 — `AIRDROP_CLAIM_CONTRACT_ADDRESS` known.** From the contract mission's mainnet deploy.
 - **Stage 0 — `CLAIM_WINDOW_OPEN_AT` decision locked.**
 - **Stage 0 — VULT prize pool funded into `AirdropClaim.sol`.** Without VULT in the contract, claims revert.
-- **`mergecontract` — `AirdropClaim.sol` deployed to mainnet** with the claim function ABI matching what we encode in step 12 of the claim flow.
+- **`vultisig-contract` — `AirdropClaim.sol` deployed to mainnet** with the claim function ABI matching what we encode in step 12 of the claim flow.
 - **Stage 2 — `agent_raffle_winners` populated.** Pre-condition for the claim handler's recipient/amount lookup.
 - **Multisig has called `setWinners(...)` on the contract** for every row in `agent_raffle_winners` before Day 28. Without this, every claim reverts on the contract's `amount == 0` check. Stage 2's `verify-onchain` subcommand is the gate that confirms this.
 - **Stage 3 — `eligibility.go` shared helper available.** Called inline from the claim handler.
@@ -380,9 +324,11 @@ docs/runbooks/
 - Confirmation monitor flips `submitted` → `confirmed` against Anvil within seconds of the receipt landing.
 - Restart test: kill mid-pipeline, restart, observe monitor pick up unfinished work.
 - Rebroadcast endpoint succeeds with bumped gas; original tx is replaced by the new one.
-- `/internal/relayer/balance` returns sane values; low-balance flag flips at the configured threshold.
-- `/internal/relayer/stuck-claims` lists pending-too-long rows; empty when none.
-- `/ops` UI is reachable behind Basic Auth and renders the three pages correctly.
+- `/ops/balance` returns sane values; low-balance flag flips at the configured threshold.
+- `/ops/stuck-claims` lists pending-too-long rows; empty when none.
+- `/ops` UI is reachable behind Basic Auth and renders all four pages correctly.
 - E2E test against Foundry-deployed `AirdropClaim.sol` passes start-to-finish: register → win raffle → multisig calls setWinners → complete quests → claim → VULT received at recipient.
 - Day 28 runbook drafted (`docs/runbooks/relayer-day-28.md`) covering: deploy steps, smoke test, kill switch flip-on. (No manual nonce sync step — that auto-runs on first boot.)
 - Stuck-tx runbook drafted covering: how to read `/ops/stuck-claims`, decide bump amount, handle "still stuck after rebroadcast" case (probably a free RPC throttling issue → switch RPC URL or pay for one).
+- Top-up runbook drafted (`docs/runbooks/relayer-top-up.md`): when `low_balance_warning` fires (or alert fires below 0.5 ETH), the funding multisig sends ETH to the relayer address (visible at the top of `/ops/balance`). Standard EOA send, no contract interaction. Safe to do mid-campaign at any time; no service restart needed. The relayer wallet is fundable from any wallet — there's no allow-list on the receive side.
+- End-of-campaign runbook drafted (`docs/runbooks/relayer-end-of-campaign.md`): once the claim window has decisively closed (e.g. 90 days past `CLAIM_WINDOW_OPEN_AT` with no recent claims), the multisig flips `CLAIM_ENABLED=false` (kill switch — every claim immediately 403s with `CLAIM_DISABLED`), then calls `recoverERC20(VULT, balance, treasuryAddress)` on the contract to drain the unclaimed VULT back to treasury, then optionally calls `recoverERC20` on the relayer wallet's remaining ETH (sent from the relayer via a one-off KMS-signed tx, or just left to fund a future campaign). Document the multisig signers' steps and which etherscan calls to watch.


### PR DESCRIPTION
## Summary

Three rounds of changes folded into one PR. All builds on the foundation laid by #67 (Merkle drop + cleanup pass).

### 1. Stage 3 cross-team contract — quest_metadata replaces JSONB classifier

The original Stage 3 design had the airdrop module sniff raw \`action_params\` JSONB at quest-event time to classify a tx as swap / bridge / defi_action. Brittle — the airdrop module would have to know every MCP tool's bespoke shape, and recovering USD value from chain-only data is essentially impossible.

The new design has the **agent layer** (MCP build_* tools + agent-backend's scheduler) pre-compute a normalised \`quest_metadata\` block at proposal-creation time, persisted on the \`agent_tx_proposals\` row. The airdrop module then reads \`tool_name\` + \`quest_metadata\` and dispatches via a clean lookup table.

\`quest_metadata\` shape (locked):
\`\`\`json
{
  \"amount_usd\":         25.50,
  \"token_in_symbol\":    \"USDC\",
  \"token_out_symbol\":   \"ETH\",
  \"source_chain_id\":    1,
  \"dest_chain_id\":      1,
  \"target_contract\":    \"0x...\",
  \"router_address\":     \"0x...\"
}
\`\`\`

Tracked as Stage 0 row 12 (cross-team schema lock). MCP team + agent-backend team both have hard-blocker prerequisites before Stage 3 ships.

### 2. Drift + simplification pass (18 items)

Cleanup of internal inconsistencies + ten meaningful simplifications. Highlights:
- Stage 1 status response always returns the full shape (with safe defaults) and now includes \`claim_tx_hash\` so the mobile app doesn't need to keep local state across reinstalls.
- \`/airdrop/stats\` drops Redis (sub-ms Postgres query against a small table doesn't need a cache).
- \`/internal/relayer/balance\` and \`/internal/relayer/stuck-claims\` HTTP routes dropped — served directly from \`/ops/*\` over Basic Auth. Halves Stage 4's endpoint count.
- Relayer nonce auto-inits from chain on first boot — removes the manual psql UPDATE Day 28 footgun.
- \`previous_tx_hashes TEXT[]\` column dropped — audit trail lives in structured logs.
- \`agent_quest_events.payload JSONB\` replaced with \`tx_proposal_id UUID\` soft reference (the metadata lives on \`agent_tx_proposals\` already; no need to duplicate).
- \`airdrop_quest_event_status\` enum collapsed to \`counted BOOLEAN\` (two-value enum overhead doesn't earn its keep).
- BROADCAST_REJECTED status code: 500 → 503 (transient, matches the other RPC errors).
- End-of-campaign + relayer top-up runbooks added to Stage 4 done-when.
- Winner-correction process documented in Stage 2 (multisig can re-call setWinners with a corrected address — important Day 28+ ops capability).
- Basic Auth inlined in the ops handler (single use, no shared middleware needed).

### 3. Grounding pass against actual repos

Verified each spec assumption against the four touched repos (\`agent-backend\`, \`vultisig/mcp\`, \`vultisig/vultisig-contract\`, \`vultisig/vultiagent-app\`). Findings actioned:

- **Repo rename:** \`vultisig/mergecontract\` → \`vultisig/vultisig-contract\` (16 instances across 7 files). The repo name in the original spec was wrong.
- **\"Fork of ETHClaim.sol\"** was aspirational — no such contract exists in vultisig-contract. \`AirdropClaim.sol\` is net-new code, patterned after the repo's existing \`Stake.sol\` / \`Token.sol\`.
- **Multisig owner address + VULT mainnet token address** elevated to Stage 0 hard prerequisites — no precedent in vultisig-contract's existing deploy scripts. Both are required constructor arguments for AirdropClaim.sol.
- **Terra-only fallback UI** in the mobile spec is net-new logic — vultiagent-app has no existing helper to extend. Flagged accordingly so the mobile engineer scopes it correctly.
- **EVM derivation helper** pinned to exact path: \`vultiagent-app/src/services/auth/addressDerivation.ts:50\`.
- **MCP scope** refined: build_evm_tx is ~5 lines (data already in result), build_swap_tx is ~25 lines (CoinGecko price lookup needed for amount_usd; \`bundle.Quote.Router\` needs exposing; chain IDs must be JSON numbers not strings — currently MCP uses strings).
- All file paths cited in cross-team task descriptions are now grounded in actual file:line locations.

## Files changed

8 spec files. No code touched.

## Test plan

- [ ] Read \`overview.md\` end-to-end and confirm it still reads cleanly to a new engineer
- [ ] Confirm Stage 3 cross-team contract with MCP team + agent-backend team — they need to commit to the schema before Stage 3 starts
- [ ] Confirm with treasury team: multisig owner address + VULT mainnet address (both Stage 0 hard prereqs now)
- [ ] Mobile engineer ack: Terra-only fallback is net-new work, not bundled into existing migration PRs

## Out of scope (kept in plans dir, not committed to this repo)

The four implementation plans live in \`/Users/apotheosis/git/vultisig/plans/airdrop/\` (parent directory, not a git repo). They reflect all the same revisions as this PR. The user will move them to whichever repo they should live in before execution begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)