### PR TITLE
fix(ios): align VaultSharing podspec with sibling module to fix linking

### DIFF
--- a/modules/vault-sharing/ios/VaultSharing.podspec
+++ b/modules/vault-sharing/ios/VaultSharing.podspec
@@ -5,17 +5,17 @@ Pod::Spec.new do |s|
   s.description    = 'Expo native module providing file sharing with proper completion detection'
   s.author         = ''
   s.homepage       = 'https://docs.expo.dev/modules/'
-  s.platforms      = {
-    :ios => '15.1',
-  }
+  s.platforms      = { ios: '15.1' }
+  s.swift_version  = '5.9'
   s.source         = { git: '' }
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
 
+  s.source_files = '**/*.{h,m,swift}'
+
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
   }
-
-  s.source_files = "*.{h,m,mm,swift,hpp,cpp}"
 end


### PR DESCRIPTION
## Summary
- Brings `modules/vault-sharing/ios/VaultSharing.podspec` in line with the working `LegacyKeystoreMigration.podspec`: adds `s.swift_version = '5.9'` and `SWIFT_COMPILATION_MODE => 'wholemodule'`, plus matches `s.source_files` style.
- Fixes runtime error `Cannot find native module 'VaultSharing'` thrown by `requireNativeModule('VaultSharing')` when `ExportPrivateKey` or `migration/BackupScreen` is rendered.

## Root cause
The original podspec (added in 3ded01c on 20 Apr) was missing `s.swift_version` and a wholemodule compilation flag. Under Xcode 26's new debug-dylib link path, `libVaultSharing.a` was dead-stripped from the final `Vultisig.debug.dylib` even though `ExpoModulesProvider.swift` referenced `VaultSharingModule.self` — the linker didn't see a strong enough reference because Swift was compiling per-file rather than wholemodule. The native module simply wasn't registered in the running app.

This was latent with Xcode prior to 26 (older link path was less aggressive about dead-stripping). It surfaced after the local Xcode upgrade to 26.4.1 (installed 27 Apr).

## Verification
- Before fix: `nm Vultisig.debug.dylib | grep VaultSharing` → 0 symbols.
- After fix: 55 symbols, including `VaultSharingModule` class metadata.
- App boots past the runtime error; export-private-key and migration backup screens load.

## Test plan
- [ ] Run `npx expo run:ios` against an iPhone simulator on Xcode 26.x and verify the app loads without the "Cannot find native module 'VaultSharing'" red-screen.
- [ ] Open the export-private-key flow and trigger a share — confirm the share sheet appears.
- [ ] Open the migration backup flow and trigger a backup share — confirm the share sheet appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)