### PR TITLE
chore(ios): drop iPad support to unblock 5.0.0 App Store submission

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,7 +19,7 @@
     },
     "ios": {
       "backgroundColor": "#02122B",
-      "supportsTablet": true,
+      "supportsTablet": false,
       "bundleIdentifier": "money.terra.station",
       "appleTeamId": "4268K8DFX6",
       "buildNumber": "1",


### PR DESCRIPTION
## Summary
- Sets \`ios.supportsTablet\` to \`false\` in \`app.json\` so prebuild emits \`TARGETED_DEVICE_FAMILY = "1"\` (iPhone only) in the generated Xcode project.
- App Store Connect was blocking the 5.0.0 submission with: *"You must upload a screenshot for 13-inch iPad displays."* This change removes iPad from the app's supported destinations so the iPad screenshot is no longer required.

## Why
Vultisig is shipped as iPhone-only in practice. With \`supportsTablet: true\`, Apple required us to provide a 13-inch iPad screenshot before allowing review submission, even though we don't intend to support iPad at this time.

## Test plan
- [ ] Run a production EAS build and verify the resulting IPA installs only on iPhone (not iPad).
- [ ] In App Store Connect, confirm the iPad screenshot requirement is gone and the build can be added for review.

## Related
A production iOS build was already cut and submitted from this branch's content (build \`50000004\`, EAS build \`9f1bc35c-27a6-4618-abcd-e3206b8420f5\`) — this PR is the source-of-truth on \`main\` for that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)