### PR TITLE
chore(release): bump version to 5.0.4

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Vultisig",
     "slug": "vultisig",
-    "version": "5.0.3",
+    "version": "5.0.4",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Release 5.0.4

Patch release rolling up this cycle's migration UX polish. Single-file diff: bumps `expo.version` in `app.json` from `5.0.3` → `5.0.4`. iOS `buildNumber` and Android `versionCode` are **auto-incremented by EAS** (`autoIncrement: true` in `eas.json` production profile), so they don't need manual bumps.

## What's in this release

### Feature work (already in flight on separate PRs)

- **#73 — feat(migration): wire up "Share your OG status" button on MigrationSuccess** — shares the bundled OG card PNG via the system share sheet (`expo-sharing`).
- **#74 — fix(migration): scrollable BackupScreen options body** — the third InfoBox ("If you lose your backup password...") was visually overlapping the consent checkbox + "Backup without Password" / "Use Password" CTAs on shorter devices (e.g. iPhone 15). Body wrapped in a `ScrollView`; bottom consent + CTA block stays pinned.
- **#74 — refactor(migration): drop redundant KeyIcon on BackupScreen options step** — the 64×64 surface1 KeyIcon was eating ~80px between the Rive splash and title without adding signal.

Merge order suggestion: **#73 → #74 → this PR**, so the "release version" commit lands on top of all the features.

## Why a separate PR for the version bump

Matches the convention from the prior 5 releases (5.0.0 → 5.0.1 → 5.0.2 → 5.0.3) — each had its own `chore(release): bump version to X.X.X` commit on a dedicated branch, separate from feature work. Lets the release commit be cleanly tagged and reverted independently.

## Build plan

After this PR merges:

```
# iOS
eas build --profile production --platform ios

# Android
eas build --profile production --platform android
```

Both builds will inherit the `autoIncrement` bump.

## Verification

- `app.json` `expo.version`: `5.0.3` → `5.0.4` ✓
- `app.json` `ios.buildNumber`: unchanged (EAS auto-increments) ✓
- `app.json` `android.versionCode`: unchanged (EAS auto-increments) ✓
- `eas.json` `production.autoIncrement: true` confirms the auto-increment policy ✓

## Refs

- #73 — Share OG status button
- #74 — BackupScreen overflow fix + KeyIcon removal
- Prior pattern: `bd2b824` (5.0.3), `260942e` (5.0.2), `a3c9b0e` (5.0.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
