### PR TITLE
fix(ios): address Apple review feedback (name + iPad layout)

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "Vultisig",
+    "name": "Station Wallet",
     "slug": "vultisig",
     "version": "5.0.5",
     "orientation": "portrait",

--- a/src/screens/migration/VaultSetup.tsx
+++ b/src/screens/migration/VaultSetup.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {
   View,
+  ScrollView,
   StyleSheet,
   Dimensions,
   PixelRatio,
@@ -123,17 +124,32 @@ function LockIcon(): React.ReactElement {
   )
 }
 
+const BOTTOM_PAD_TOP = 12
+const BOTTOM_BUTTON_AREA = MIGRATION.ctaHeight + BOTTOM_PAD_TOP
+
 export default function VaultSetup(): React.ReactElement {
   const navigation = useNavigation<Nav>()
   const insets = useSafeAreaInsets()
+  const safeBottom = Math.max(insets.bottom, 16)
+
+  const handleBack = (): void => {
+    if (navigation.canGoBack()) navigation.goBack()
+  }
 
   return (
     <View style={styles.container}>
       <View style={{ paddingTop: insets.top }}>
-        <MigrationToolbar onBack={() => navigation.goBack()} />
+        <MigrationToolbar onBack={handleBack} />
       </View>
 
-      <View style={styles.content}>
+      <ScrollView
+        style={styles.contentScroll}
+        contentContainerStyle={[
+          styles.content,
+          { paddingBottom: BOTTOM_BUTTON_AREA + safeBottom },
+        ]}
+        showsVerticalScrollIndicator={false}
+      >
         <Text fontType="brockmann-medium" style={styles.title}>
           Your vault setup
         </Text>
@@ -187,13 +203,11 @@ export default function VaultSetup(): React.ReactElement {
           title="Multisig with one device"
           description="A co-signer can never initiate transactions; only assists with signing them."
         />
-      </View>
+      </ScrollView>
 
       <View
-        style={[
-          styles.bottom,
-          { paddingBottom: Math.max(insets.bottom, 16) },
-        ]}
+        pointerEvents="box-none"
+        style={[styles.bottom, { paddingBottom: safeBottom }]}
       >
         <Button
           testID="vault-setup-get-started"
@@ -213,8 +227,10 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: MIGRATION.bg,
   },
-  content: {
+  contentScroll: {
     flex: 1,
+  },
+  content: {
     paddingHorizontal: 24,
   },
   title: {
@@ -307,7 +323,12 @@ const styles = StyleSheet.create({
     lineHeight: 18,
   },
   bottom: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
     paddingHorizontal: 24,
-    paddingBottom: 16,
+    paddingTop: BOTTOM_PAD_TOP,
+    backgroundColor: MIGRATION.bg,
   },
 })


### PR DESCRIPTION
Addresses 2 of 3 items from Apple's review of v5.0.0 (50000004) on iPad Air 11" (M3) / iPadOS 26.4.1.

## Guideline 2.3.8 — Display name mismatch
Marketplace listing is "Station Wallet" but on-device name was "Vultisig". Renamed `expo.name` in `app.json` so the next prebuild regenerates `CFBundleDisplayName` as "Station Wallet". Bundle ID, slug, scheme, Xcode folder, and icon are unchanged — important because the legacy bundle ID `money.terra.station` must stay (Terra→Vultisig team-transfer keychain continuity).

## Guideline 4 — Crowded UI on `Your vault setup`

Apple's reviewed build had `supportsTablet: false` already, so the iPad sim ran the app in iPhone compatibility mode. The compatibility window has a different aspect than any real iPhone, so the original fixed-position content didn't fit and the CTA collided with the feature rows. Reproduced exactly on iPhone SE (3rd gen, 375×667pt) at default text.

Fix:
- Wrap content in `ScrollView` so it can scroll on short heights.
- Pin the bottom CTA via `position: absolute` with a solid background, and pad the scroll content to clear it. Content scrolls cleanly under the CTA on any screen height.
- No `flexGrow:1` on the scroll content — that was inflating children and blanking the layout on tall screens.

### Before — CTA overlaps "No long setup..." description (Apple's exact bug)

<img width="750" height="1334" alt="vault-setup-BEFORE-fix" src="https://github.com/user-attachments/assets/8dbd7202-5e31-4a87-a361-a4147b58346b" />

### After — iPhone SE (short screen): CTA pinned, content scrolls cleanly

<img width="750" height="1334" alt="vault-setup-AFTER-fix" src="https://github.com/user-attachments/assets/644b3dac-20d7-4789-a984-5f5597d945c6" />

### After — iPhone 17 Pro: all content fits, no scroll needed

<img width="1206" height="2622" alt="vault-setup-AFTER-iphone17pro" src="https://github.com/user-attachments/assets/49e2a660-bc4b-411f-acb9-1d61367cda72" />

### After — iPad Air 11" (full-tablet rendering): all content fits with room to spare

<img width="1640" height="2360" alt="vault-setup-AFTER-ipad" src="https://github.com/user-attachments/assets/78f9c40a-0ef4-494f-b003-d56598686967" />

## Guideline 2.1(a) — Demo access
**Not in this PR.** Recommended approach is a server-side bypass in `vultiserver` for a dedicated review email + rotated bypass code. Tracking separately.

## Test plan
- [ ] iOS prebuild regenerates `CFBundleDisplayName` as "Station Wallet" from `expo.name`
- [ ] iPhone SE / short-aspect compatibility window: CTA pinned, content scrolls without overlap (validated)
- [ ] iPhone 17 Pro: layout unchanged, all content fits (validated)
- [ ] iPad Air 11": layout fits, no regression (validated)
- [ ] No regression on `Create New Wallet` → `VaultName` flow (this branch leaves migration entry unchanged)

## Screenshots
Saved at `~/Desktop/vault-setup-*.png` — drag them into the placeholders above on github.com (gh CLI can't embed images in PR descriptions).