### PR TITLE
refactor(migration): make MigrationToolbar.onBack optional

### DIFF
--- a/src/components/migration/MigrationToolbar.tsx
+++ b/src/components/migration/MigrationToolbar.tsx
@@ -19,7 +19,7 @@ function ChevronLeftIcon(): React.ReactElement {
 }
 
 type Props = {
-  onBack: () => void
+  onBack?: () => void
   testID?: string
   children?: React.ReactNode
 }
@@ -31,9 +31,13 @@ export default function MigrationToolbar({
 }: Props): React.ReactElement {
   return (
     <View style={styles.toolbar}>
-      <GlassButton onPress={onBack} testID={testID}>
-        <ChevronLeftIcon />
-      </GlassButton>
+      {onBack ? (
+        <GlassButton onPress={onBack} testID={testID}>
+          <ChevronLeftIcon />
+        </GlassButton>
+      ) : (
+        <View />
+      )}
       {children}
     </View>
   )


### PR DESCRIPTION
Follow-up to #77 review.

Currently, `MigrationToolbar` requires `onBack: () => void`. Every migration screen passes `() => navigation.goBack()`, which throws React Navigation's "The action 'GO_BACK' was not handled by any navigator" error if the screen is reached as the stack's initial route (e.g. via deep link, dev flag, or RiveIntro race condition).

This PR makes `onBack` optional. When undefined, the chevron is not rendered — the toolbar leaves a placeholder so any `children` continue to layout correctly via the existing `space-between` flex.

## Why this lives in the Toolbar, not at call sites

Putting a `navigation.canGoBack()` guard on every screen's back handler would touch every migration screen and still leave a visible-but-non-functional chevron in edge cases. Letting the Toolbar accept `undefined` lets call sites express "no back" intent declaratively:

```tsx
<MigrationToolbar
  onBack={navigation.canGoBack() ? handleBack : undefined}
/>
```

Call sites that always have a back stack continue to pass `onBack` and behave identically.

## Scope

- No call site changes — existing usages still pass `onBack`, type system accepts them.
- Future screens / call sites can now opt out cleanly.
- Pairs with the local `canGoBack()` guard added in #77 — a follow-up could replace that local guard with the toolbar pattern, but that's not done here to keep PRs focused.

## Test plan
- [ ] All existing migration screens render with their back chevron unchanged
- [ ] A screen passing `onBack={undefined}` renders the toolbar with no chevron and no crash
- [ ] No TypeScript regressions (`onBack?` is purely additive)