### PR TITLE
copy(migration): replace countdown with "This window closes soon."

### DIFF
--- a/src/components/migration/InfoCard.tsx
+++ b/src/components/migration/InfoCard.tsx
@@ -74,12 +74,10 @@ function CalendarClockIcon(): React.ReactElement {
 }
 
 type Props = {
-  daysRemaining: number
   connectedBottom?: boolean
 }
 
 export default function InfoCard({
-  daysRemaining,
   connectedBottom = false,
 }: Props): React.ReactElement {
   return (
@@ -149,7 +147,7 @@ export default function InfoCard({
         <View style={styles.countdownStrip}>
           <CalendarClockIcon />
           <Text fontType="brockmann-medium" style={styles.countdown}>
-            The window closes in {daysRemaining} days.
+            This window closes soon.
           </Text>
         </View>
       )}

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -63,22 +63,12 @@ function CalendarClockIcon(): React.ReactElement {
 
 type Nav = StackNavigationProp<MigrationStackParams, 'MigrationHome'>
 
-/** Migration deadline — 30 days from a fixed launch date. */
-const MIGRATION_DEADLINE = new Date('2026-05-09T00:00:00Z')
-
-function computeDaysRemaining(): number {
-  const now = new Date()
-  const diff = MIGRATION_DEADLINE.getTime() - now.getTime()
-  return Math.max(0, Math.ceil(diff / (1000 * 60 * 60 * 24)))
-}
-
 export default function MigrationHome(): React.ReactElement {
   const insets = useSafeAreaInsets()
   const navigation = useNavigation<Nav>()
   const [wallets, setWallets] = useState<MigrationWallet[]>([])
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- setReady used to track loading state
   const [_ready, setReady] = useState(false)
-  const daysRemaining = computeDaysRemaining()
 
   useEffect(() => {
     discoverLegacyWallets()
@@ -133,10 +123,7 @@ export default function MigrationHome(): React.ReactElement {
             entering={FadeIn.delay(1200).duration(300)}
             style={styles.cardWrapper}
           >
-            <InfoCard
-              daysRemaining={daysRemaining}
-              connectedBottom={!MIGRATION_FLOW_ENABLED}
-            />
+            <InfoCard connectedBottom={!MIGRATION_FLOW_ENABLED} />
             {!MIGRATION_FLOW_ENABLED && (
               <View
                 style={styles.checkBackCard}


### PR DESCRIPTION
Removes the hardcoded `2026-05-09` migration deadline and the day-counter from `MigrationHome` / `InfoCard`. Copy now reads `This window closes soon.` regardless of date.

## Why
- Previously: `The window closes in {N} days.` driven by a hardcoded `MIGRATION_DEADLINE` constant. Once the date passes, it would clamp to "0 days" and read awkwardly.
- The deadline isn't enforced anywhere — it's purely UX copy. A static line is simpler and survives the actual cutoff date without a build.

## Scope
- `InfoCard` no longer takes `daysRemaining` (prop removed).
- `MigrationHome` no longer computes / passes the value (`MIGRATION_DEADLINE` and `computeDaysRemaining` deleted).
- No other call sites used the prop.

## Test plan
- [ ] `MigrationHome` renders with the new copy on a fresh install
- [ ] No TypeScript errors after the prop removal
- [ ] Copy still only shown when `MIGRATION_FLOW_ENABLED` (unchanged)