### PR TITLE
chore(navigation): replace __DEV__ Auth gate with explicit env flag

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -11,9 +11,6 @@ export const MIGRATION_FLOW_ENABLED =
  * When `true`, fresh installs boot into the dev `AuthMenu` (with seed/dev
  * buttons) instead of the production migration flow. Used by Detox E2E
  * tests to seed legacy-wallet fixtures before walking the migration path.
- *
- * Default is `false` so debug builds match what ships — devs see the
- * production new-install experience without local config tweaks.
  */
 export const BYPASS_AUTH_FOR_TESTING =
   process.env.EXPO_PUBLIC_BYPASS_AUTH_FOR_TESTING === 'true'

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -7,6 +7,17 @@ export const env = {
 export const MIGRATION_FLOW_ENABLED =
   process.env.EXPO_PUBLIC_MIGRATION_FLOW_ENABLED === 'true'
 
+/**
+ * When `true`, fresh installs boot into the dev `AuthMenu` (with seed/dev
+ * buttons) instead of the production migration flow. Used by Detox E2E
+ * tests to seed legacy-wallet fixtures before walking the migration path.
+ *
+ * Default is `false` so debug builds match what ships — devs see the
+ * production new-install experience without local config tweaks.
+ */
+export const BYPASS_AUTH_FOR_TESTING =
+  process.env.EXPO_PUBLIC_BYPASS_AUTH_FOR_TESTING === 'true'
+
 const showDevFeatures =
   __DEV__ && process.env.EXPO_PUBLIC_SHOW_DEV_FEATURES === 'true'
 

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -76,9 +76,6 @@ export default function AppNavigator(): React.ReactElement | null {
       ) {
         setRootRoute('Migration')
       } else if (loaded.length === 0) {
-        // Default route is the production migration flow. Detox tests flip
-        // BYPASS_AUTH_FOR_TESTING=true to land on AuthMenu instead, where
-        // they can tap dev seed buttons before walking the migration path.
         setRootRoute(BYPASS_AUTH_FOR_TESTING ? 'Auth' : 'Migration')
       } else {
         setRootRoute('Main')

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -19,7 +19,10 @@ import { WalletNavContext } from './hooks'
 import preferences, {
   PreferencesEnum,
 } from 'nativeModules/preferences'
-import { MIGRATION_FLOW_ENABLED } from 'config/env'
+import {
+  MIGRATION_FLOW_ENABLED,
+  BYPASS_AUTH_FOR_TESTING,
+} from 'config/env'
 
 export { useWalletDisconnected, useWalletNav } from './hooks'
 
@@ -73,9 +76,10 @@ export default function AppNavigator(): React.ReactElement | null {
       ) {
         setRootRoute('Migration')
       } else if (loaded.length === 0) {
-        // In dev mode, show Auth first so E2E dev seed buttons are accessible.
-        // In production, brand new users go straight to the migration/creation flow.
-        setRootRoute(__DEV__ ? 'Auth' : 'Migration')
+        // Default route is the production migration flow. Detox tests flip
+        // BYPASS_AUTH_FOR_TESTING=true to land on AuthMenu instead, where
+        // they can tap dev seed buttons before walking the migration path.
+        setRootRoute(BYPASS_AUTH_FOR_TESTING ? 'Auth' : 'Migration')
       } else {
         setRootRoute('Main')
       }
@@ -153,7 +157,7 @@ export default function AppNavigator(): React.ReactElement | null {
     if ((wallets?.length ?? 0) > 0) {
       setRootRoute('Main')
     } else {
-      setRootRoute(__DEV__ ? 'Auth' : 'Migration')
+      setRootRoute(BYPASS_AUTH_FOR_TESTING ? 'Auth' : 'Migration')
     }
   }, [wallets])
 


### PR DESCRIPTION
## Why

The decision between booting into the dev `AuthMenu` (with seed/dev buttons) vs the production migration flow on a fresh install was hardcoded to `__DEV__`. That meant developers running debug builds *never* saw what actually ships — they always landed on the dev menu, while users on a release build go straight into the migration onboarding.

This makes it easy to miss UX bugs that only show up on the production path (the rejected iPad layout in #77 is one example — that screen lives on the production path the dev menu hides).

## What

Add `EXPO_PUBLIC_BYPASS_AUTH_FOR_TESTING` (default `false`) to gate the AuthMenu route.

```ts
// before
setRootRoute(__DEV__ ? 'Auth' : 'Migration')

// after
setRootRoute(BYPASS_AUTH_FOR_TESTING ? 'Auth' : 'Migration')
```

Affects two sites in `src/navigation/index.tsx` (initial-route selection + `goHome` fallback). New flag exported from `src/config/env.ts` with docs.

## Behaviour

| Flag | Outcome | Used by |
|---|---|---|
| `false` (default) | Production migration flow on fresh install | Devs running debug builds, prod users |
| `true` | `AuthMenu` shown, with `dev-*` seed buttons | Detox E2E tests |

## What this does NOT touch

- `DevFlags.SeedLegacyData / .SeedCorruptData / .VerifyVault / .StateReset` keep their `__DEV__` gating in `config/env.ts`. Those control debug features that must never be enabled in release builds even if a stray env var is set.
- `STUB_VULTISERVER` keeps its `__DEV__` gating for the same reason.

The `__DEV__` we're removing is *only* the onboarding-route decision — orthogonal to debug-feature visibility.

## Detox / E2E follow-up

Detox tests (in `fix-detox-e2e` branch — not yet on `main`) tap `dev-create-fast-vault` on the AuthMenu to seed fixtures before walking the migration flow. Those tests need to set `EXPO_PUBLIC_BYPASS_AUTH_FOR_TESTING=true` in their `.env.test` (already loaded by `e2e/helpers/`) so the AuthMenu remains reachable. **This change is owed to whoever ships the Detox PR — flagging here so it doesn't get missed.**

## .env

Local `.env` (gitignored) needs the new line. The existing `.env` template pattern in this repo doesn't include a tracked `.env.example`, so I haven't added one. If we want one as part of this PR I'll add it.

```
EXPO_PUBLIC_BYPASS_AUTH_FOR_TESTING=false
```

## Test plan
- [ ] Debug build with `EXPO_PUBLIC_BYPASS_AUTH_FOR_TESTING=false` (or unset): fresh install boots into `RiveIntro` → `MigrationHome` (production path)
- [ ] Debug build with `EXPO_PUBLIC_BYPASS_AUTH_FOR_TESTING=true`: fresh install boots into `AuthMenu` (existing test path), `dev-*` seed buttons render when `EXPO_PUBLIC_SHOW_DEV_FEATURES=true`
- [ ] Release build (no env var): unchanged — production migration flow
- [ ] No regression on the already-onboarded user path (`Main` route when `wallets.length > 0`)
- [ ] After Detox merge: tests set the flag in their env and continue to find seed buttons