### PR TITLE
Track airdrop bucket metadata

### DIFF
--- a/__tests__/migration/legacy-keystore.test.ts
+++ b/__tests__/migration/legacy-keystore.test.ts
@@ -42,6 +42,23 @@ function buildAuthData(): string {
   })
 }
 
+function buildStampedAuthData(authData: string): string {
+  const parsed = JSON.parse(authData)
+  return JSON.stringify({
+    ...parsed,
+    TestWallet1: {
+      ...parsed.TestWallet1,
+      airdropBucket: 'station_migration',
+      airdropRegistrationSource: 'seed',
+    },
+    TestWallet2: {
+      ...parsed.TestWallet2,
+      airdropBucket: 'station_migration',
+      airdropRegistrationSource: 'seed',
+    },
+  })
+}
+
 // resetSecure() also wipes preferences state — the production
 // `nativeModules/preferences` writes into `expo-secure-store`, and
 // babel-plugin-module-resolver rewrites the `nativeModules/*` alias
@@ -52,14 +69,16 @@ beforeEach(() => {
 })
 
 describe('migrateLegacyKeystore', () => {
-  it('seeds, migrates, and reads back identical bytes', async () => {
+  it('seeds, migrates, and stamps airdrop metadata', async () => {
     const authData = buildAuthData()
     await LegacyKeystore.seedLegacyTestData(KeystoreEnum.AuthData, authData)
     expect(await LegacyKeystore.readLegacy(KeystoreEnum.AuthData)).toBe(authData)
 
     await migrateLegacyKeystore()
 
-    expect(await keystore.read(KeystoreEnum.AuthData)).toBe(authData)
+    expect(await keystore.read(KeystoreEnum.AuthData)).toBe(
+      buildStampedAuthData(authData)
+    )
   })
 
   it('cleans up legacy data after successful migration', async () => {
@@ -74,7 +93,9 @@ describe('migrateLegacyKeystore', () => {
     await LegacyKeystore.seedLegacyTestData(KeystoreEnum.AuthData, authData)
     await migrateLegacyKeystore()
     await migrateLegacyKeystore()
-    expect(await keystore.read(KeystoreEnum.AuthData)).toBe(authData)
+    expect(await keystore.read(KeystoreEnum.AuthData)).toBe(
+      buildStampedAuthData(authData)
+    )
   })
 
   it('sets the legacyKeystoreMigrated preference flag', async () => {

--- a/__tests__/migration/legacy-keystore.test.ts
+++ b/__tests__/migration/legacy-keystore.test.ts
@@ -59,6 +59,34 @@ function buildStampedAuthData(authData: string): string {
   })
 }
 
+function buildLedgerOnlyAuthData(): string {
+  return JSON.stringify({
+    TestLedgerWallet: {
+      ledger: true,
+      address: 'terra1test000e2e000ledger001',
+      path: 0,
+    },
+  })
+}
+
+function buildPreStampedAuthData(): string {
+  return JSON.stringify({
+    TestWallet1: {
+      ledger: false,
+      address: 'terra1test000e2e000wallet001',
+      password: 'testPassword1!',
+      encryptedKey: encrypt(PK1, 'testPassword1!'),
+      airdropBucket: 'campaign_new',
+      airdropRegistrationSource: 'vault_share',
+    },
+    TestLedgerWallet: {
+      ledger: true,
+      address: 'terra1test000e2e000ledger001',
+      path: 0,
+    },
+  })
+}
+
 // resetSecure() also wipes preferences state — the production
 // `nativeModules/preferences` writes into `expo-secure-store`, and
 // babel-plugin-module-resolver rewrites the `nativeModules/*` alias
@@ -133,6 +161,44 @@ describe('migrateLegacyKeystore', () => {
       address: 'terra1test000e2e000ledger001',
       path: 0,
     })
+  })
+
+  it('preserves ledger-only legacy data without stamping buckets', async () => {
+    const authData = buildLedgerOnlyAuthData()
+    await LegacyKeystore.seedLegacyTestData(KeystoreEnum.AuthData, authData)
+
+    await migrateLegacyKeystore()
+
+    expect(await keystore.read(KeystoreEnum.AuthData)).toBe(authData)
+  })
+
+  it('preserves pre-stamped airdrop metadata', async () => {
+    const authData = buildPreStampedAuthData()
+    await LegacyKeystore.seedLegacyTestData(KeystoreEnum.AuthData, authData)
+
+    await migrateLegacyKeystore()
+
+    expect(await keystore.read(KeystoreEnum.AuthData)).toBe(authData)
+  })
+
+  it('does not migrate malformed legacy entries', async () => {
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    await LegacyKeystore.seedLegacyTestData(
+      KeystoreEnum.AuthData,
+      JSON.stringify({ BrokenWallet: 'not-an-object' })
+    )
+
+    await migrateLegacyKeystore()
+
+    expect(await keystore.read(KeystoreEnum.AuthData)).toBe('')
+    expect(
+      await preferences.getBool(
+        PreferencesEnum.legacyKeystoreMigrated
+      )
+    ).toBe(false)
+    consoleSpy.mockRestore()
   })
 
   it('derives expected secp256k1 public key from decrypted wallet 1', async () => {

--- a/src/screens/migration/VerifyEmail.tsx
+++ b/src/screens/migration/VerifyEmail.tsx
@@ -26,10 +26,36 @@ import { MIGRATION } from 'consts/migration'
 import { verifyVaultEmail } from 'services/fastVaultServer'
 import { storeFastVault } from 'services/migrateToVault'
 import { getErrorMessage } from 'utils/getErrorMessage'
+import type {
+  AirdropBucket,
+  AirdropRegistrationSource,
+} from 'utils/authData'
 import type { MigrationStackParams } from 'navigation/MigrationNavigator'
 
 type Nav = StackNavigationProp<MigrationStackParams, 'VerifyEmail'>
 type Route = RouteProp<MigrationStackParams, 'VerifyEmail'>
+
+function airdropMetadataForMode(mode: Route['params']['mode']): {
+  airdropBucket: AirdropBucket
+  airdropRegistrationSource: AirdropRegistrationSource
+} {
+  if (mode === 'migrate') {
+    return {
+      airdropBucket: 'station_migration',
+      airdropRegistrationSource: 'seed',
+    }
+  }
+  if (mode === 'create') {
+    return {
+      airdropBucket: 'campaign_new',
+      airdropRegistrationSource: 'create',
+    }
+  }
+  return {
+    airdropBucket: 'campaign_new',
+    airdropRegistrationSource: 'seed',
+  }
+}
 
 function EmailCircleIcon(): React.ReactElement {
   return (
@@ -104,7 +130,11 @@ export default function VerifyEmail(): React.ReactElement {
       // legacy auth data. Doing this after verify means a failure at any
       // earlier point leaves the legacy wallet recoverable.
       try {
-        await storeFastVault(walletName, keyImportResult)
+        await storeFastVault(
+          walletName,
+          keyImportResult,
+          airdropMetadataForMode(mode)
+        )
         // The isFastVault status for this wallet just flipped from
         // false -> true. Invalidate the cached query so WalletList
         // re-renders the migrated wallet with the correct CTA instead

--- a/src/services/importVaultBackup.ts
+++ b/src/services/importVaultBackup.ts
@@ -123,6 +123,8 @@ export async function persistImportedVault(
         encryptedKey: '',
         password: '',
         ledger: false,
+        airdropBucket: 'campaign_new',
+        airdropRegistrationSource: 'vault_share',
       },
     },
   })

--- a/src/services/migrateToVault.ts
+++ b/src/services/migrateToVault.ts
@@ -9,6 +9,8 @@ import {
   upsertAuthData,
   AuthDataValueType,
   LedgerDataValueType,
+  AirdropBucket,
+  AirdropRegistrationSource,
 } from 'utils/authData'
 import preferences, {
   PreferencesEnum,
@@ -39,6 +41,13 @@ export interface MigrationResult {
   wallet: MigrationWallet
   success: boolean
   error?: string
+}
+
+export interface StoreFastVaultOptions {
+  airdropBucket?: AirdropBucket
+  airdropRegistrationSource?: AirdropRegistrationSource
+  airdropRecipientAddress?: string
+  airdropRegisteredAt?: string
 }
 
 /**
@@ -80,7 +89,8 @@ export async function getStoredVault(
  */
 export async function storeFastVault(
   walletName: string,
-  result: KeyImportResult
+  result: KeyImportResult,
+  options: StoreFastVaultOptions = {}
 ): Promise<void> {
   if (await isVaultFastVault(walletName)) {
     // eslint-disable-next-line no-console -- important diagnostic for double-migration attempts
@@ -138,6 +148,16 @@ export async function storeFastVault(
           password: '',
           ledger: false,
           terraOnly: true,
+          airdropBucket:
+            entry.airdropBucket ?? options.airdropBucket,
+          airdropRegistrationSource:
+            entry.airdropRegistrationSource ??
+            options.airdropRegistrationSource,
+          airdropRecipientAddress:
+            entry.airdropRecipientAddress ??
+            options.airdropRecipientAddress,
+          airdropRegisteredAt:
+            entry.airdropRegisteredAt ?? options.airdropRegisteredAt,
         },
       },
     })
@@ -150,6 +170,11 @@ export async function storeFastVault(
           encryptedKey: '',
           password: '',
           ledger: false,
+          airdropBucket: options.airdropBucket ?? 'campaign_new',
+          airdropRegistrationSource:
+            options.airdropRegistrationSource,
+          airdropRecipientAddress: options.airdropRecipientAddress,
+          airdropRegisteredAt: options.airdropRegisteredAt,
         },
       },
     })

--- a/src/services/migrateToVault.ts
+++ b/src/services/migrateToVault.ts
@@ -169,7 +169,7 @@ export async function storeFastVault(
           encryptedKey: '',
           password: '',
           ledger: false,
-          airdropBucket: options.airdropBucket ?? 'campaign_new',
+          airdropBucket: options.airdropBucket,
           airdropRegistrationSource:
             options.airdropRegistrationSource,
           airdropRecipientAddress: options.airdropRecipientAddress,

--- a/src/services/migrateToVault.ts
+++ b/src/services/migrateToVault.ts
@@ -148,8 +148,7 @@ export async function storeFastVault(
           password: '',
           ledger: false,
           terraOnly: true,
-          airdropBucket:
-            entry.airdropBucket ?? options.airdropBucket,
+          airdropBucket: entry.airdropBucket ?? options.airdropBucket,
           airdropRegistrationSource:
             entry.airdropRegistrationSource ??
             options.airdropRegistrationSource,

--- a/src/utils/authData.ts
+++ b/src/utils/authData.ts
@@ -1,12 +1,19 @@
 import keystore, { KeystoreEnum } from 'nativeModules/keystore'
 import _ from 'lodash'
 
+export type AirdropBucket = 'station_migration' | 'campaign_new'
+export type AirdropRegistrationSource = 'seed' | 'vault_share' | 'create'
+
 export type AuthDataValueType = {
   ledger?: false
   encryptedKey: string
   address: string
   password: string
   terraOnly?: boolean
+  airdropBucket?: AirdropBucket
+  airdropRegistrationSource?: AirdropRegistrationSource
+  airdropRecipientAddress?: string
+  airdropRegisteredAt?: string
 }
 
 export type LedgerDataValueType = {

--- a/src/utils/authData.ts
+++ b/src/utils/authData.ts
@@ -2,7 +2,10 @@ import keystore, { KeystoreEnum } from 'nativeModules/keystore'
 import _ from 'lodash'
 
 export type AirdropBucket = 'station_migration' | 'campaign_new'
-export type AirdropRegistrationSource = 'seed' | 'vault_share' | 'create'
+export type AirdropRegistrationSource =
+  | 'seed'
+  | 'vault_share'
+  | 'create'
 
 export type AuthDataValueType = {
   ledger?: false

--- a/src/utils/legacyMigration.ts
+++ b/src/utils/legacyMigration.ts
@@ -100,7 +100,9 @@ export async function migrateLegacyKeystore(): Promise<void> {
     ]).finally(() => clearTimeout(timer!))
     if (legacyData) {
       // Validate and stamp legacy Station wallets before writing.
-      const stampedData = stampLegacyAirdropBucket(JSON.parse(legacyData))
+      const stampedData = stampLegacyAirdropBucket(
+        JSON.parse(legacyData)
+      )
 
       // Write to new expo-secure-store location
       await SecureStore.setItemAsync(

--- a/src/utils/legacyMigration.ts
+++ b/src/utils/legacyMigration.ts
@@ -5,21 +5,26 @@ import preferences, {
 } from 'nativeModules/preferences'
 import { LEGACY_ACCOUNT, keychainOpts } from 'nativeModules/keystore'
 import type {
-  AuthDataType,
   AuthDataValueType,
   LedgerDataValueType,
 } from './authData'
 
-function stampLegacyAirdropBucket(raw: unknown): AuthDataType {
+type LegacyAuthData = Record<
+  string,
+  AuthDataValueType | LedgerDataValueType
+>
+
+function stampLegacyAirdropBucket(raw: unknown): LegacyAuthData {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
     throw new Error('Legacy auth data must be an object')
   }
 
-  const stamped: Exclude<AuthDataType, undefined> = {}
+  const stamped: LegacyAuthData = {}
   for (const [walletName, value] of Object.entries(raw)) {
     if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      stamped[walletName] = value as AuthDataValueType
-      continue
+      throw new Error(
+        `Legacy auth data entry ${walletName} must be an object`
+      )
     }
 
     const entry = value as AuthDataValueType | LedgerDataValueType

--- a/src/utils/legacyMigration.ts
+++ b/src/utils/legacyMigration.ts
@@ -4,6 +4,41 @@ import preferences, {
   PreferencesEnum,
 } from 'nativeModules/preferences'
 import { LEGACY_ACCOUNT, keychainOpts } from 'nativeModules/keystore'
+import type {
+  AuthDataType,
+  AuthDataValueType,
+  LedgerDataValueType,
+} from './authData'
+
+function stampLegacyAirdropBucket(raw: unknown): AuthDataType {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('Legacy auth data must be an object')
+  }
+
+  const stamped: Exclude<AuthDataType, undefined> = {}
+  for (const [walletName, value] of Object.entries(raw)) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      stamped[walletName] = value as AuthDataValueType
+      continue
+    }
+
+    const entry = value as AuthDataValueType | LedgerDataValueType
+    if (entry.ledger === true) {
+      stamped[walletName] = entry
+      continue
+    }
+
+    const authEntry = entry as AuthDataValueType
+    stamped[walletName] = {
+      ...authEntry,
+      airdropBucket: authEntry.airdropBucket ?? 'station_migration',
+      airdropRegistrationSource:
+        authEntry.airdropRegistrationSource ?? 'seed',
+    }
+  }
+
+  return stamped
+}
 
 /**
  * Migrate wallet data from the old native Keystore module to expo-secure-store.
@@ -64,13 +99,13 @@ export async function migrateLegacyKeystore(): Promise<void> {
       }),
     ]).finally(() => clearTimeout(timer!))
     if (legacyData) {
-      // Validate it's parseable JSON before writing
-      JSON.parse(legacyData)
+      // Validate and stamp legacy Station wallets before writing.
+      const stampedData = stampLegacyAirdropBucket(JSON.parse(legacyData))
 
       // Write to new expo-secure-store location
       await SecureStore.setItemAsync(
         LEGACY_ACCOUNT,
-        legacyData,
+        JSON.stringify(stampedData),
         keychainOpts('AD')
       )
 

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -143,6 +143,8 @@ export const addWallet = async ({
       },
     })
   } else {
+    // addWallet is only used by the seed/recover path; Fast Vault
+    // creation is stamped from VerifyEmail via storeFastVault.
     return await upsertAuthData({
       authData: {
         [wallet.name]: {

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -151,6 +151,8 @@ export const addWallet = async ({
           password: password || '',
           encryptedKey: key || '',
           terraOnly: true,
+          airdropBucket: 'campaign_new',
+          airdropRegistrationSource: 'seed',
         },
       },
     })


### PR DESCRIPTION
## Context
The campaign needs two airdrop buckets: wallets migrated from existing Station keychain data, and wallets added during the campaign period. Station mobile is the only codebase that can reliably know whether a wallet came from the legacy Station keychain, so it needs to stamp that metadata locally before the authenticated registration flow submits it to the backend.

## Related PRs
- Backend storage/API support: https://github.com/vultisig/agent-backend/pull/216.
- Backend Stage 1 boarding base PR: https://github.com/vultisig/agent-backend/pull/169. The bucket backend PR is downstream of this.
- Matching spec/docs update: https://github.com/ai-combinator/vultihub/pull/23.

## Summary
- stamp legacy Station keychain wallets as station_migration during secure-store migration
- stamp campaign-added wallets as campaign_new across create, recover seed, fast-vault, and imported vault-share flows
- carry source metadata separately from bucket metadata so backend registration can submit both
- tighten legacy auth-data stamping behavior and expand migration test coverage

## Verification
- git diff --check
- GitHub CI passed on commit 95dd37f: Lint, Typecheck, Unit Tests