### PR TITLE
fix(backup): honor "no password" by storing plain vault + isEncrypted=false

### DIFF
--- a/__tests__/vault/import-file.test.ts
+++ b/__tests__/vault/import-file.test.ts
@@ -1,10 +1,15 @@
 import * as fs from 'fs'
 import * as path from 'path'
 
+import { create, toBinary } from '@bufbuild/protobuf'
+import { base64 } from '@scure/base'
+
 import {
   importVaultBackup,
   type ImportVaultBackupResult,
 } from 'services/importVaultBackup'
+import { encryptWithPassword } from 'services/vaultCrypto'
+import { VaultContainerSchema } from '../../src/proto/vultisig/vault/v1/vault_container_pb'
 
 type Decrypted = Extract<ImportVaultBackupResult, { needsPassword: false }>
 function assertDecrypted(r: ImportVaultBackupResult): Decrypted {
@@ -84,5 +89,70 @@ describe('importVaultBackup — .bak', () => {
     )
     expect(result.vaultName).toBeTruthy()
     expect(result.publicKeyEcdsa).toBeTruthy()
+  })
+})
+
+// Mirrors the export semantic so we can test imports of "no password"
+// containers without spinning up expo-file-system in jest.
+function buildContainerBase64(
+  vaultBytes: Uint8Array,
+  password: string | null,
+): string {
+  const hasPassword =
+    typeof password === 'string' && password.length > 0
+  const containerVaultBytes = hasPassword
+    ? encryptWithPassword(vaultBytes, password)
+    : vaultBytes
+  const container = create(VaultContainerSchema, {
+    version: 1n,
+    isEncrypted: hasPassword,
+    vault: base64.encode(containerVaultBytes),
+  })
+  return base64.encode(toBinary(VaultContainerSchema, container))
+}
+
+describe('importVaultBackup — no-password export roundtrip', () => {
+  // Recover the raw vault bytes from the encrypted fixture so we can
+  // re-pack them as a plain (no-password) container.
+  const decrypted = assertDecrypted(
+    importVaultBackup({
+      content: readFixture(vultPath),
+      fileName: 'test-vault.vult',
+      password: FIXTURE_PASSWORD,
+    }),
+  )
+  const innerVaultBytes = decrypted.vaultBytes
+
+  it('imports a no-password container without prompting', () => {
+    const content = buildContainerBase64(innerVaultBytes, null)
+    const result = assertDecrypted(
+      importVaultBackup({
+        content,
+        fileName: 'test-vault-station-mobile.vult',
+      }),
+    )
+    expect(result.vaultName).toBe(decrypted.vaultName)
+    expect(result.publicKeyEcdsa).toBe(decrypted.publicKeyEcdsa)
+  })
+
+  it('imports a password-protected container only with the password', () => {
+    const customPassword = 'custompass-456'
+    const content = buildContainerBase64(innerVaultBytes, customPassword)
+
+    expect(
+      importVaultBackup({
+        content,
+        fileName: 'test-vault-station-mobile.vult',
+      }),
+    ).toEqual({ needsPassword: true })
+
+    const result = assertDecrypted(
+      importVaultBackup({
+        content,
+        fileName: 'test-vault-station-mobile.vult',
+        password: customPassword,
+      }),
+    )
+    expect(result.vaultName).toBe(decrypted.vaultName)
   })
 })

--- a/src/screens/migration/BackupScreen.tsx
+++ b/src/screens/migration/BackupScreen.tsx
@@ -144,7 +144,9 @@ export default function BackupVault(): React.ReactElement {
     )
   }
 
-  const runExport = async (password: string): Promise<void> => {
+  const runExport = async (
+    password: string | null
+  ): Promise<void> => {
     if (!walletName) return
     setExporting(true)
     try {
@@ -165,12 +167,7 @@ export default function BackupVault(): React.ReactElement {
   }
 
   const handleBackupWithoutPassword = async (): Promise<void> => {
-    // Without a user-provided password, use the walletName itself as
-    // the encryption key — it's still encrypted on disk, just not with
-    // a secret only the user knows. Matches vultiagent-app's
-    // "without password" semantic (the container is still encrypted,
-    // just with a deterministic key from the vault data).
-    await runExport(walletName)
+    await runExport(null)
   }
 
   const handleBackupWithCustomPassword = async (): Promise<void> => {

--- a/src/services/exportVaultShare.ts
+++ b/src/services/exportVaultShare.ts
@@ -15,18 +15,21 @@ import { getStoredVault } from './migrateToVault'
 import { encryptWithPassword } from './vaultCrypto'
 
 /**
- * Exports a wallet as an encrypted .vult vault share file.
+ * Exports a wallet as a .vult vault share file.
  *
  * For DKLS fast vaults: reads the stored vault protobuf directly.
  * For legacy vaults: constructs a KeyImport vault protobuf from the raw
  * secp256k1 private key (privateKeyHex must be provided).
  *
- * Encrypts with AES-256-GCM, wraps in VaultContainer, and writes to a
- * shareable .vult file importable by any Vultisig app via "Import Vault Share".
+ * If `exportPassword` is a non-empty string, the vault is encrypted with
+ * AES-256-GCM and `isEncrypted` is set to true. If null/undefined/empty,
+ * the vault bytes are stored plain and `isEncrypted` is false — matching
+ * vultisig-windows and vultisig-ios behavior so the file imports cleanly
+ * without prompting for a password.
  */
 export async function exportVaultShare(
   walletName: string,
-  exportPassword: string,
+  exportPassword: string | null,
   privateKeyHex?: string // Only needed for legacy vaults
 ): Promise<string> {
   let vaultBytes: Uint8Array
@@ -60,15 +63,16 @@ export async function exportVaultShare(
     )
     vaultBytes = toBinary(VaultSchema, vaultProto)
   }
-  const encryptedBytes = encryptWithPassword(
-    vaultBytes,
-    exportPassword
-  )
+  const hasPassword =
+    typeof exportPassword === 'string' && exportPassword.length > 0
+  const containerVaultBytes = hasPassword
+    ? encryptWithPassword(vaultBytes, exportPassword)
+    : vaultBytes
 
   const container = create(VaultContainerSchema, {
     version: 1n,
-    isEncrypted: true,
-    vault: base64.encode(encryptedBytes),
+    isEncrypted: hasPassword,
+    vault: base64.encode(containerVaultBytes),
   })
 
   const containerBytes = toBinary(VaultContainerSchema, container)


### PR DESCRIPTION
## Why

When the user picks **"Backup without Password"**, the resulting `.vult` file is rejected by our own importer with a password prompt — but the user has nothing to enter.

Root cause: `exportVaultShare` always encrypts and always sets `isEncrypted: true`, regardless of whether a password was provided. The "without password" path in `BackupScreen` works around this by passing the wallet name as a fake key (`runExport(walletName)`), producing a container that is *technically encrypted* but with a key derived from publicly visible metadata. On re-import, `importVaultBackup` correctly sees `isEncrypted: true` and prompts — leaving the user stuck.

This is a station-mobile-only deviation. **vultisig-windows** ([`useBackupVaultMutation.ts:36-58`](https://github.com/vultisig/vultisig-windows/blob/main/core/ui/vault/mutations/useBackupVaultMutation.ts)) and **vultisig-ios** ([`EncryptedBackupViewModel.swift:118-142`](https://github.com/vultisig/vultisig-ios/blob/main/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift)) both branch on whether a password was supplied — encrypt + `isEncrypted: true` if yes, plain bytes + `isEncrypted: false` if no. That's the correct semantic and is what station-mobile's own importer is already prepared to handle (see `importVaultBackup.ts:60-69`).

## What changed

- **`src/services/exportVaultShare.ts`**: `exportPassword` is now `string | null`. When non-empty, encrypt + `isEncrypted: true` (unchanged). When null/empty, store plain vault bytes + `isEncrypted: false`. Matches the windows/ios shape exactly.
- **`src/screens/migration/BackupScreen.tsx`**: `handleBackupWithoutPassword` now calls `runExport(null)` instead of the wallet-name-as-key workaround. `runExport` signature widened to `string | null`.
- **`__tests__/vault/import-file.test.ts`**: two new tests using a small `buildContainerBase64` helper that mirrors the export semantic. Verifies (a) a no-password container imports without prompting and roundtrips name + pubkey; (b) a password-protected container still requires the password and only decrypts with it.

## Backward compatibility

**Existing "without-password" backups produced by station-mobile <= 5.0.5 will still prompt for a password on import** because they are genuinely encrypted (with the wallet name as key). They were unimportable in practice anyway — the user has no password to enter. The "encryption" in those files was security-theater since the key was derived from publicly visible filename metadata.

If telemetry shows existing users affected, a follow-up PR can add a fallback in `importVaultBackup`: when `isEncrypted: true` and the file matches `*-station-mobile.vult`, try the filename-derived wallet name as a silent fallback before showing the password sheet.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint:check` clean (after auto-fix)
- [x] `npx jest` — 116/116 tests pass, including 2 new roundtrip cases
- [ ] **Manual**: install build on device, create a vault, "Backup without Password", re-import the resulting `.vult` — should land on home screen without a password prompt
- [ ] **Manual**: same flow with a password — re-import should require the password
- [ ] **Manual**: ensure `.vult` files from vultisig-windows / vultisig-ios still import unchanged (no regression in existing import paths)

Manual testing not run because the local sideload was blocked on team provisioning earlier today; the tests above prove the encode/decode roundtrip in jest.

## Files

- `src/services/exportVaultShare.ts` (+13 / -10)
- `src/screens/migration/BackupScreen.tsx` (+5 / -7)
- `__tests__/vault/import-file.test.ts` (+70 / -0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)