### PR TITLE
chore: rename app to "Station Wallet" — slug + Bluetooth permission

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
     "name": "Station Wallet",
-    "slug": "vultisig",
+    "slug": "station-wallet",
     "version": "5.0.5",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -25,7 +25,7 @@
       "buildNumber": "1",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
-        "NSBluetoothAlwaysUsageDescription": "Vultisig uses Bluetooth to connect to supported hardware wallets (such as Ledger) for secure transaction signing."
+        "NSBluetoothAlwaysUsageDescription": "Station Wallet uses Bluetooth to connect to supported hardware wallets (such as Ledger) for secure transaction signing."
       },
       "entitlements": {
         "aps-environment": "production"


### PR DESCRIPTION
## Summary

Two user-visible `Vultisig` brand references in `app.json` updated to match the already-correct `expo.name = "Station Wallet"`:

- **`expo.slug`**: `vultisig` → `station-wallet`
- **iOS Bluetooth permission prompt** (`NSBluetoothAlwaysUsageDescription`): `Vultisig uses Bluetooth to connect to supported hardware wallets...` → `Station Wallet uses Bluetooth...`

The home-screen app name (`expo.name`) was already `Station Wallet` — these were the remaining places where the rebrand hadn't propagated.

## Deliberately not changed

| Reference | Why kept |
|---|---|
| `@vultisig/mpc-native` plugin | Real npm package name (the MPC-signing native module) |
| `owner: "vultisig"` | Expo organization owner — changing it loses EAS access |
| `src/consts/vultisig.ts` | Internal brand design tokens (color palette), not user-visible |
| `vultisigApiUrl: 'https://api.vultisig.com'` | Internal API endpoint, separate infra concern |
| Migration screen copy | Intentional product language about the TerraStation → Vultisig migration flow |

## Risk note

The `slug` change affects EAS update URL slugs. `extra.eas.projectId` UUID is unchanged so the project stays linked. Already-issued OTA updates are keyed off `projectId`, not slug, so they remain valid. Any CI scripts that hard-code `slug=vultisig` in EAS update channels need a follow-up grep — easy to fix in a small follow-up if discovered.

## Test plan

- [ ] `expo prebuild --clean --platform ios` — generated Info.plist `NSBluetoothAlwaysUsageDescription` reads "Station Wallet uses Bluetooth..."
- [ ] `expo prebuild --clean --platform android` — `android:label` resolves to "Station Wallet" (already correct via `expo.name`)
- [ ] EAS update channel still posts updates against the same project UUID
- [ ] Fresh install on Pixel emulator + iPhone sim shows "Station Wallet" on home screen + Bluetooth perm dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)