### PR TITLE
chore: revert expo.slug to "vultisig" to match EAS project

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
     "name": "Station Wallet",
-    "slug": "station-wallet",
+    "slug": "vultisig",
     "version": "5.0.5",
     "orientation": "portrait",
     "icon": "./assets/icon.png",


### PR DESCRIPTION
## Summary
- Reverts the `expo.slug` change from b3bc253 (`vultisig` → `station-wallet`).
- EAS slugs are immutable server-side, so the rename broke `eas build`:
  > Slug for project identified by `extra.eas.projectId` (vultisig) does not match the `slug` field (station-wallet).
- `expo.name` stays `"Station Wallet"` and the Bluetooth permission copy from b3bc253 is preserved.

## Why a separate PR
Production builds were already running locally with this change applied to a dirty tree (iOS + Android queued on EAS). Landing this on `main` keeps the repo and EAS in sync for future builds.

## Test plan
- [x] `eas build -p ios --profile production` accepts the config (build queued: https://expo.dev/accounts/vultisig/projects/vultisig/builds/8ff96f3b-af8a-404a-b2ee-13f61a7cba02)
- [x] `eas build -p android --profile production` accepts the config (build queued: https://expo.dev/accounts/vultisig/projects/vultisig/builds/25f99d42-6f91-40ba-87f0-ef2a4746321b)
- [ ] App still displays as "Station Wallet" once builds finish

🤖 Generated with [Claude Code](https://claude.com/claude-code)