### PR TITLE
chore(rebrand): rename "Station Wallet" → "Station"

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "Station Wallet",
+    "name": "Station",
     "slug": "vultisig",
     "version": "5.0.5",
     "orientation": "portrait",
@@ -25,7 +25,7 @@
       "buildNumber": "1",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
-        "NSBluetoothAlwaysUsageDescription": "Station Wallet uses Bluetooth to connect to supported hardware wallets (such as Ledger) for secure transaction signing."
+        "NSBluetoothAlwaysUsageDescription": "Station uses Bluetooth to connect to supported hardware wallets (such as Ledger) for secure transaction signing."
       },
       "entitlements": {
         "aps-environment": "production"

--- a/src/screens/auth/AuthMenu.tsx
+++ b/src/screens/auth/AuthMenu.tsx
@@ -44,7 +44,7 @@ const AuthMenu = ({
             <Text style={styles.logoText}>S</Text>
           </View>
           <Text style={[authStyles.title, { fontSize: 28 }]}>
-            Station Wallet
+            Station
           </Text>
           <Text
             style={[


### PR DESCRIPTION
## Summary

Rename the user-facing "Station Wallet" → "Station" across the three source-of-truth strings:

| File | Change |
|------|--------|
| `app.json` `expo.name` | `"Station Wallet"` → `"Station"` (drives iOS `CFBundleDisplayName` + Android `app_name` via `expo prebuild`) |
| `app.json` `infoPlist.NSBluetoothAlwaysUsageDescription` | `"Station Wallet uses Bluetooth..."` → `"Station uses Bluetooth..."` |
| `src/screens/auth/AuthMenu.tsx:47` | logo title text `Station Wallet` → `Station` |

## Why

Brand decision: ship as **Station**, not "Station Wallet". The `Wallet` suffix was a placeholder during the rebrand (introduced in `b3bc253` in PR #84). Cleaning it up now so users see the brand name on first install + every Bluetooth permission prompt.

## What's NOT in this PR

- The Xcode project / scheme / target identifier (`StationWallet.xcodeproj`, target name, Pods name) are **internal build identifiers**, not user-visible. Kept as-is to avoid the churn of renaming Xcode references across pbxproj files.
- `ios/StationWallet/Info.plist` is **regenerated from `app.json` on `expo prebuild`**, not source of truth. Untracked / will be rewritten on next prebuild.
- `package.json` `"name": "TerraStation"` is the npm package name (internal), not user-visible.
- Bundle identifier `money.terra.station` stays — changing it would break update delivery to existing installs.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint:check` — clean
- [ ] Verify on iOS sim after `expo prebuild --clean -p ios`: app installs with display name "Station" (not "Station Wallet"), Bluetooth permission prompt reads "Station uses Bluetooth..."
- [ ] Verify auth menu logo card shows "Station" title

## receipts

(small text-only rename; pre-fix label vs post-fix label is the visible delta — verifiable on next dev/preview build)
