### PR TITLE
chore(branding): shorten home-screen label to "Station"

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "Station Wallet",
+    "name": "Station",
     "slug": "vultisig",
     "version": "5.0.5",
     "orientation": "portrait",


### PR DESCRIPTION
## Summary
- Update `expo.name` in `app.json` from `Station Wallet` → `Station`
- Avoids label truncation on Android launchers (the longer label was clipping mid-word for users on smaller-screen devices)
- Internal slug, project ID, owner, and `package`/`bundleIdentifier` are unchanged — purely a user-visible label change

## Test plan
- [ ] EAS production build picks up the new name and `android:label` reflects `Station`
- [ ] Install resulting APK/AAB on Android — home-screen icon reads `Station`
- [ ] iOS install — Springboard label reads `Station`
- [ ] Confirm Play Store / App Store listing names are managed separately and unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)