### PR TITLE
chore(release): bump version 5.0.5 → 5.0.6

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Station Wallet",
     "slug": "vultisig",
-    "version": "5.0.5",
+    "version": "5.0.6",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary
- 5.0.5 is already shipped on Play Store
- Bump `expo.version` so the next release surfaces 5.0.6 in About → Version
- `versionCode` is auto-incremented by EAS (`appVersionSource=remote`), so this only changes the user-visible string

## Test plan
- [ ] Production AAB built from this branch reports 5.0.6 in About → Version
- [ ] Play Console accepts the upload (versionCode auto-increments past 50000010)

🤖 Generated with [Claude Code](https://claude.com/claude-code)