### PR TITLE
Add seed recovery to initial mobile screen

### DIFF
--- a/__tests__/migration/keystore-size.test.ts
+++ b/__tests__/migration/keystore-size.test.ts
@@ -1,6 +1,9 @@
 import { encrypt } from 'utils/crypto'
 import keystore, { KeystoreEnum } from 'nativeModules/keystore'
-import { __reset as resetSecure } from '../__mocks__/expo-secure-store'
+
+const { __reset: resetSecure } = jest.requireMock(
+  'expo-secure-store'
+) as typeof import('../__mocks__/expo-secure-store')
 
 const PK =
   '0000000000000000000000000000000000000000000000000000000000000001'

--- a/__tests__/migration/legacy-keystore.test.ts
+++ b/__tests__/migration/legacy-keystore.test.ts
@@ -4,7 +4,6 @@ import { hex } from '@scure/base'
 import LegacyKeystore, {
   __reset as resetLegacy,
 } from '../__mocks__/legacy-keystore'
-import { __reset as resetSecure } from '../__mocks__/expo-secure-store'
 import preferences, {
   PreferencesEnum,
 } from 'nativeModules/preferences'
@@ -12,6 +11,10 @@ import preferences, {
 import { migrateLegacyKeystore } from 'utils/legacyMigration'
 import { encrypt, decrypt } from 'utils/crypto'
 import keystore, { KeystoreEnum } from 'nativeModules/keystore'
+
+const { __reset: resetSecure } = jest.requireMock(
+  'expo-secure-store'
+) as typeof import('../__mocks__/expo-secure-store')
 
 const PK1 =
   '0000000000000000000000000000000000000000000000000000000000000001'
@@ -46,9 +49,11 @@ function buildAuthData(): string {
 // `nativeModules/preferences` writes into `expo-secure-store`, and
 // babel-plugin-module-resolver rewrites the `nativeModules/*` alias
 // before jest moduleNameMapper runs, so the preferences mock is unused.
-beforeEach(() => {
+beforeEach(async () => {
   resetLegacy()
   resetSecure()
+  await keystore.remove(KeystoreEnum.AuthData)
+  await preferences.clear()
 })
 
 describe('migrateLegacyKeystore', () => {

--- a/__tests__/wallet/vault-store.test.ts
+++ b/__tests__/wallet/vault-store.test.ts
@@ -1,11 +1,14 @@
 import { create, toBinary, fromBinary } from '@bufbuild/protobuf'
 import { base64 } from '@scure/base'
 
-import { __reset as resetSecure } from '../__mocks__/expo-secure-store'
 import { persistImportedVault } from 'services/importVaultBackup'
 import { getStoredVault } from 'services/migrateToVault'
 import { VaultSchema } from '../../src/proto/vultisig/vault/v1/vault_pb'
 import { LibType } from '../../src/proto/vultisig/keygen/v1/lib_type_message_pb'
+
+const { __reset: resetSecure } = jest.requireMock(
+  'expo-secure-store'
+) as typeof import('../__mocks__/expo-secure-store')
 
 beforeEach(() => {
   resetSecure()

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -24,7 +24,6 @@ import {
   MigrationWallet,
 } from 'services/migrateToVault'
 import type { MigrationStackParams } from 'navigation/MigrationNavigator'
-import AddWalletSheet from 'components/AddWalletSheet'
 
 type Nav = StackNavigationProp<MigrationStackParams, 'MigrationHome'>
 
@@ -41,19 +40,12 @@ export default function MigrationHome(): React.ReactElement {
   const [wallets, setWallets] = useState<MigrationWallet[]>([])
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- setReady used to track loading state
   const [_ready, setReady] = useState(false)
-  const [importSheetVisible, setImportSheetVisible] = useState(false)
   // We're already inside the Migration navigator here, so the root-route
   // dance in `useWalletNav` is a no-op (setRootRoute('Migration') doesn't
   // re-mount the navigator, and `initialRouteName` is only read once at
   // mount). Push the right screen directly via the local stack nav.
   const startSeedRecoveryFromHere = (): void => {
     navigation.navigate('RecoverSeed')
-  }
-  const startImportVaultFromHere = (): void => {
-    navigation.navigate('ImportVault')
-  }
-  const startCreateVaultFromHere = (): void => {
-    navigation.navigate('VaultName', { mode: 'create' })
   }
 
   useEffect(() => {
@@ -152,12 +144,12 @@ export default function MigrationHome(): React.ReactElement {
             />
 
             <Button
-              title="Import wallet"
+              title="Recover Wallet"
               theme="secondaryDark"
               titleFontType="brockmann-medium"
-              onPress={() => setImportSheetVisible(true)}
+              onPress={startSeedRecoveryFromHere}
               containerStyle={styles.secondaryButton}
-              testID="import-vault-button"
+              testID="recover-seed-button"
             />
 
             <TouchableOpacity
@@ -202,18 +194,6 @@ export default function MigrationHome(): React.ReactElement {
           )}
         </View>
       </ScrollView>
-
-      <AddWalletSheet
-        visible={importSheetVisible}
-        onDismiss={() => setImportSheetVisible(false)}
-        onCreate={startCreateVaultFromHere}
-        onRecover={startSeedRecoveryFromHere}
-        onImport={startImportVaultFromHere}
-        // MigrationHome's "Import wallet" entry is for users who already
-        // have a wallet — Create would just be a misroute. The shared sheet
-        // still defaults to showing it for the WalletList entry.
-        showCreate={false}
-      />
     </View>
   )
 }


### PR DESCRIPTION
## Summary
- Add a production-visible Recover Wallet action to the initial migration home screen.
- Route it to the existing RecoverSeed flow so users can enter a seed phrase without first importing an existing wallet.
- Remove the redundant initial-screen Import wallet entry; vault share import remains available from the existing add-wallet sheet elsewhere.
- Fix SecureStore mock reset usage in related tests so CI starts from a clean mocked keystore state.

## Runtime proof
Initial migration screen with Recover Wallet button:

![Initial migration screen with Recover Wallet button](https://files.catbox.moe/3iv9w8.png)

Seed phrase recovery screen reached from that button:

![Seed phrase recovery screen](https://files.catbox.moe/bv9sst.png)

## Receipts
- `npm run typecheck`
- `npm run lint:check`
- `git diff --check origin/main..HEAD`
- `npm run test:ci -- --runInBand --testPathIgnorePatterns='<rootDir>/.claude/' '<rootDir>/.worktrees/'`
- `EXPO_PUBLIC_BYPASS_AUTH_FOR_TESTING=false EXPO_PUBLIC_SHOW_DEV_FEATURES=false npx expo run:ios --device E852182B-812B-4198-845D-1730088443E1 --port 8095`
- `maestro --device E852182B-812B-4198-845D-1730088443E1 test /tmp/station-mobile-seed-flow.yaml`