### PR TITLE
fix(station-mobile): correct "Fast Vault" label for multi-share vaults + post-migration CTA copy

### DIFF
--- a/__tests__/migration/discover-legacy-wallets.test.ts
+++ b/__tests__/migration/discover-legacy-wallets.test.ts
@@ -1,0 +1,109 @@
+import { __reset as resetSecure } from '../__mocks__/expo-secure-store'
+import { upsertAuthData } from 'utils/authData'
+import { discoverLegacyWallets } from 'services/migrateToVault'
+
+beforeEach(() => {
+  resetSecure()
+})
+
+describe('discoverLegacyWallets filter', () => {
+  it('returns wallets that still have an encryptedKey', async () => {
+    await upsertAuthData({
+      authData: {
+        UnmigratedWallet: {
+          ledger: false,
+          address: 'terra1abc',
+          encryptedKey: 'someEncryptedKeyData',
+          password: 'pwd',
+        },
+      },
+    })
+    const found = await discoverLegacyWallets()
+    expect(found.map((w) => w.name)).toContain('UnmigratedWallet')
+  })
+
+  it('filters out entries with empty encryptedKey (already-migrated stub)', async () => {
+    await upsertAuthData({
+      authData: {
+        MigratedStub: {
+          ledger: false,
+          address: 'terra1xyz',
+          encryptedKey: '', // zeroed by storeFastVault / persistImportedVault
+          password: '',
+          terraOnly: true,
+        },
+      },
+    })
+    const found = await discoverLegacyWallets()
+    expect(found.map((w) => w.name)).not.toContain('MigratedStub')
+  })
+
+  it('always returns ledger wallets (no encryptedKey to check)', async () => {
+    await upsertAuthData({
+      authData: {
+        MyLedger: {
+          ledger: true,
+          address: 'terra1ledger',
+          path: 0,
+        },
+      },
+    })
+    const found = await discoverLegacyWallets()
+    expect(found.map((w) => w.name)).toContain('MyLedger')
+    expect(found.find((w) => w.name === 'MyLedger')?.ledger).toBe(true)
+  })
+
+  it('returns only unmigrated entries when mixed state', async () => {
+    await upsertAuthData({
+      authData: {
+        Migrated: {
+          ledger: false,
+          address: 'terra1m',
+          encryptedKey: '',
+          password: '',
+          terraOnly: true,
+        },
+        Unmigrated: {
+          ledger: false,
+          address: 'terra1u',
+          encryptedKey: 'encryptedKeyMaterial',
+          password: 'pwd',
+        },
+        LedgerWallet: {
+          ledger: true,
+          address: 'terra1l',
+          path: 1,
+        },
+      },
+    })
+    const found = await discoverLegacyWallets()
+    const names = found.map((w) => w.name)
+    expect(names).not.toContain('Migrated')
+    expect(names).toContain('Unmigrated')
+    expect(names).toContain('LedgerWallet')
+    expect(found).toHaveLength(2)
+  })
+
+  it('returns empty array when all entries are migrated stubs', async () => {
+    await upsertAuthData({
+      authData: {
+        Stub1: {
+          ledger: false,
+          address: 'terra1s1',
+          encryptedKey: '',
+          password: '',
+          terraOnly: true,
+        },
+        Stub2: {
+          ledger: false,
+          address: 'terra1s2',
+          encryptedKey: '',
+          password: '',
+          terraOnly: true,
+        },
+      },
+    })
+    const found = await discoverLegacyWallets()
+    expect(found).toHaveLength(0)
+  })
+})

--- a/__tests__/wallet/vault-kind.test.ts
+++ b/__tests__/wallet/vault-kind.test.ts
@@ -1,0 +1,82 @@
+import { create, toBinary } from '@bufbuild/protobuf'
+import { base64 } from '@scure/base'
+import * as SecureStore from '../__mocks__/expo-secure-store'
+
+import { __reset as resetSecure } from '../__mocks__/expo-secure-store'
+import { getVaultKind } from 'services/migrateToVault'
+import { VaultSchema } from '../../src/proto/vultisig/vault/v1/vault_pb'
+import { LibType } from '../../src/proto/vultisig/keygen/v1/lib_type_message_pb'
+
+// vaultStoreKey sanitises the name with a 'VAULT-' prefix — replicate here
+// so we can pre-seed SecureStore directly.
+function vaultStoreKey(name: string): string {
+  return 'VAULT-' + name.replace(/[^a-zA-Z0-9._-]/g, '_')
+}
+
+const STORE_OPTS = { keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY }
+
+async function storeVault(
+  name: string,
+  signers: string[],
+  localPartyId: string,
+  libType: LibType = LibType.DKLS,
+): Promise<void> {
+  const vault = create(VaultSchema, {
+    name,
+    publicKeyEcdsa: 'abc',
+    publicKeyEddsa: '',
+    signers,
+    localPartyId,
+    hexChainCode: '0'.repeat(64),
+    resharePrefix: '',
+    libType,
+    keyShares: [{ publicKey: 'abc', keyshare: 'share' }],
+  })
+  const encoded = base64.encode(toBinary(VaultSchema, vault))
+  await SecureStore.setItemAsync(vaultStoreKey(name), encoded, STORE_OPTS)
+}
+
+beforeEach(() => {
+  resetSecure()
+})
+
+describe('getVaultKind', () => {
+  it("returns 'none' when no vault is stored", async () => {
+    expect(await getVaultKind('NoVault')).toBe('none')
+  })
+
+  it("returns 'fast' for a device+server vault (canonical fast vault)", async () => {
+    await storeVault('FastVault', ['sdk-ABC123', 'Server-987654'], 'sdk-ABC123')
+    expect(await getVaultKind('FastVault')).toBe('fast')
+  })
+
+  it("returns 'fast' with mixed-case Server prefix", async () => {
+    await storeVault('FastVault2', ['Device', 'server-lower'], 'Device')
+    expect(await getVaultKind('FastVault2')).toBe('fast')
+  })
+
+  it("returns 'multi-share' for a 3-of-3 multi-device vault (no server signer)", async () => {
+    await storeVault(
+      'MultiVault',
+      ['iPhone-AB12', 'MacOS-CD34', 'MacOS-EF56'],
+      'iPhone-AB12',
+    )
+    expect(await getVaultKind('MultiVault')).toBe('multi-share')
+  })
+
+  it("returns 'multi-share' when localPartyId is itself server-prefixed", async () => {
+    // The server side of a 2-of-2 should not classify itself as a fast vault.
+    // This mirrors iOS Vault.swift:172 — if localPartyID starts with 'server-' → false.
+    await storeVault(
+      'ServerSideVault',
+      ['Server-12345', 'Device'],
+      'Server-12345',
+    )
+    expect(await getVaultKind('ServerSideVault')).toBe('multi-share')
+  })
+
+  it("returns 'multi-share' for a DKLS vault with a single non-server signer", async () => {
+    await storeVault('SoloVault', ['OnlyDevice'], 'OnlyDevice')
+    expect(await getVaultKind('SoloVault')).toBe('multi-share')
+  })
+})

--- a/src/components/WalletCard.tsx
+++ b/src/components/WalletCard.tsx
@@ -55,6 +55,17 @@ function CloudUploadIcon(): React.ReactElement {
   )
 }
 
+function ShieldIcon(): React.ReactElement {
+  return (
+    <Svg width={12} height={12} viewBox="0 0 24 24" fill="none">
+      <Path
+        d="M12 2L4 6v6c0 5.25 3.5 10.15 8 11.5C16.5 22.15 20 17.25 20 12V6L12 2z"
+        fill="#0B4EFF"
+      />
+    </Svg>
+  )
+}
+
 function TrashIcon(): React.ReactElement {
   return (
     <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">
@@ -73,7 +84,8 @@ type Props = {
   name: string
   address: string
   terraOnly: boolean
-  isFastVault: boolean
+  /** Canonical vault classifier: 'fast' = device+VultiServer, 'multi-share' = multi-device, 'none' = legacy (no stored vault) */
+  vaultKind: 'none' | 'fast' | 'multi-share'
   onPress: () => void
   onExport?: () => void
   onDelete?: () => void
@@ -84,7 +96,7 @@ export default function WalletCard({
   name,
   address,
   terraOnly,
-  isFastVault,
+  vaultKind,
   onPress,
   onExport,
   onDelete,
@@ -161,7 +173,7 @@ export default function WalletCard({
           />
         )}
 
-        {isFastVault ? (
+        {vaultKind === 'fast' ? (
           <View style={styles.fastVaultChip}>
             <View style={styles.fastVaultIconCircle}>
               <Svg
@@ -194,6 +206,18 @@ export default function WalletCard({
               style={styles.fastVaultChipText}
             >
               Fast Vault
+            </Text>
+          </View>
+        ) : vaultKind === 'multi-share' ? (
+          <View style={styles.multiShareChip}>
+            <View style={styles.fastVaultIconCircle}>
+              <ShieldIcon />
+            </View>
+            <Text
+              fontType="brockmann-medium"
+              style={styles.fastVaultChipText}
+            >
+              Vault
             </Text>
           </View>
         ) : (
@@ -275,6 +299,18 @@ const styles = StyleSheet.create({
     borderRadius: MIGRATION.radiusSmallButton,
   },
   fastVaultChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: MIGRATION.smallButtonHeight,
+    backgroundColor: MIGRATION.buttonSecondary,
+    borderRadius: MIGRATION.radiusPill,
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.1)',
+    paddingHorizontal: 12,
+    gap: 8,
+    marginLeft: 'auto',
+  },
+  multiShareChip: {
     flexDirection: 'row',
     alignItems: 'center',
     height: MIGRATION.smallButtonHeight,

--- a/src/screens/WalletList.tsx
+++ b/src/screens/WalletList.tsx
@@ -13,7 +13,7 @@ import { useQueries } from 'react-query'
 import { useWalletNav } from 'navigation/hooks'
 import { settings } from 'utils/storage'
 import { deleteWallet } from 'utils/wallet'
-import { isVaultFastVault } from 'services/migrateToVault'
+import { getVaultKind } from 'services/migrateToVault'
 import { MIGRATION } from 'consts/migration'
 import { DevFlags } from 'config/env'
 import Text from 'components/Text'
@@ -53,27 +53,31 @@ export default function WalletList(): React.ReactElement {
     }, [refreshWallets])
   )
 
-  // Per-wallet fast-vault status, cached by wallet name. react-query
-  // keeps data across renders, so navigating back to this screen
-  // doesn't blink the loading overlay — existing cards stay up while
-  // stale data revalidates in the background.
-  const fastVaultQueries = useQueries(
+  // Per-wallet vault-kind, cached by wallet name. react-query keeps data
+  // across renders, so navigating back to this screen doesn't blink the
+  // loading overlay — existing cards stay up while stale data revalidates
+  // in the background.
+  const vaultKindQueries = useQueries(
     wallets.map((w) => ({
-      queryKey: ['isFastVault', w.name],
-      queryFn: (): Promise<boolean> => isVaultFastVault(w.name),
+      queryKey: ['vaultKind', w.name],
+      queryFn: (): Promise<'none' | 'fast' | 'multi-share'> =>
+        getVaultKind(w.name),
       staleTime: 30_000,
     }))
   )
-  const fastVaultMap: Record<string, boolean> = {}
+  const vaultKindMap: Record<
+    string,
+    'none' | 'fast' | 'multi-share'
+  > = {}
   wallets.forEach((w, i) => {
-    const result = fastVaultQueries[i]
-    if (result?.data !== undefined) fastVaultMap[w.name] = result.data
+    const result = vaultKindQueries[i]
+    if (result?.data !== undefined) vaultKindMap[w.name] = result.data
   })
   // Only show the blocking overlay on the very first resolve, not on
   // revalidations triggered by focus. isLoading is react-query's
   // "never-resolved-yet" signal; isFetching would fire on every refetch.
   const loading =
-    wallets.length > 0 && fastVaultQueries.some((q) => q.isLoading)
+    wallets.length > 0 && vaultKindQueries.some((q) => q.isLoading)
 
   const [addSheetVisible, setAddSheetVisible] = useState(false)
 
@@ -86,7 +90,10 @@ export default function WalletList(): React.ReactElement {
   const handlePress = async (wallet: LocalWallet): Promise<void> => {
     await settings.set({ walletName: wallet.name })
 
-    if (fastVaultMap[wallet.name]) {
+    if (
+      vaultKindMap[wallet.name] === 'fast' ||
+      vaultKindMap[wallet.name] === 'multi-share'
+    ) {
       if (inMigrationNav) {
         migrationNav.navigate('MigrationSuccess', {
           migratedWalletName: wallet.name,
@@ -175,7 +182,7 @@ export default function WalletList(): React.ReactElement {
             name={wallet.name}
             address={wallet.address}
             terraOnly={wallet.terraOnly === true}
-            isFastVault={fastVaultMap[wallet.name] === true}
+            vaultKind={vaultKindMap[wallet.name] ?? 'none'}
             onPress={() => handlePress(wallet)}
             onExport={() => handleExport(wallet)}
             onDelete={() => handleDelete(wallet)}

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -23,6 +23,8 @@ import {
   discoverLegacyWallets,
   MigrationWallet,
 } from 'services/migrateToVault'
+import { getWallets } from 'utils/wallet'
+import { useWalletNav } from 'navigation/hooks'
 import type { MigrationStackParams } from 'navigation/MigrationNavigator'
 import AddWalletSheet from 'components/AddWalletSheet'
 
@@ -39,6 +41,7 @@ export default function MigrationHome(): React.ReactElement {
   const heroSize = isShort ? 140 : 200
   const titleMargin = isShort ? 16 : 28
   const [wallets, setWallets] = useState<MigrationWallet[]>([])
+  const [totalWalletCount, setTotalWalletCount] = useState(0)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- setReady used to track loading state
   const [_ready, setReady] = useState(false)
   const [importSheetVisible, setImportSheetVisible] = useState(false)
@@ -56,10 +59,13 @@ export default function MigrationHome(): React.ReactElement {
     navigation.navigate('VaultName', { mode: 'create' })
   }
 
+  const { goHome } = useWalletNav()
+
   useEffect(() => {
-    discoverLegacyWallets()
-      .then((found) => {
+    Promise.all([discoverLegacyWallets(), getWallets()])
+      .then(([found, all]) => {
         setWallets(found)
+        setTotalWalletCount(all.length)
         setReady(true)
       })
       .catch(() => {
@@ -67,11 +73,28 @@ export default function MigrationHome(): React.ReactElement {
       })
   }, [])
 
-  const hasLegacyWallets = wallets.length > 0
+  const hasUnmigratedLegacy = wallets.length > 0
+  const hasAnyVaults = totalWalletCount > 0
+
+  // CTA copy:
+  // - has unmigrated legacy AND has vaults → "Continue migration"
+  // - has unmigrated legacy, no vaults yet → "Start Migration"
+  // - no unmigrated legacy, has vaults → "See my vaults"
+  // - nothing → "Create a Fast Vault"
+  const ctaTitle =
+    hasUnmigratedLegacy && hasAnyVaults
+      ? 'Continue migration'
+      : hasUnmigratedLegacy
+      ? 'Start Migration'
+      : hasAnyVaults
+      ? 'See my vaults'
+      : 'Create a Fast Vault'
 
   const handleCta = (): void => {
-    if (hasLegacyWallets) {
+    if (hasUnmigratedLegacy) {
       navigation.navigate('WalletsFound')
+    } else if (hasAnyVaults) {
+      goHome()
     } else {
       navigation.navigate('VaultSetup')
     }
@@ -139,11 +162,7 @@ export default function MigrationHome(): React.ReactElement {
             style={styles.buttonGroup}
           >
             <Button
-              title={
-                hasLegacyWallets
-                  ? 'Start Migration'
-                  : 'Create a Fast Vault'
-              }
+              title={ctaTitle}
               theme="ctaBlue"
               titleFontType="brockmann-medium"
               onPress={handleCta}

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -73,7 +73,9 @@ export default function MigrationHome(): React.ReactElement {
         const kinds = await Promise.all(
           all.map((w) => getVaultKind(w.name))
         )
-        const realVaultCount = kinds.filter((k) => k !== 'none').length
+        const realVaultCount = kinds.filter(
+          (k) => k !== 'none'
+        ).length
         setTotalWalletCount(realVaultCount)
         setReady(true)
       })

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -94,7 +94,19 @@ export default function MigrationHome(): React.ReactElement {
     if (hasUnmigratedLegacy) {
       navigation.navigate('WalletsFound')
     } else if (hasAnyVaults) {
-      goHome()
+      // MigrationHome can be mounted at two depths:
+      //  1. Root → Migration → MigrationHome (post-init when legacyDataFound)
+      //  2. Root → Main → Migration → MigrationHome (when user back-navs from
+      //     WalletList into the nested Migration stack)
+      // In case 2 the root is already 'Main', so goHome's setRootRoute('Main')
+      // is a no-op and the screen looks frozen. Pop the parent stack to
+      // WalletList directly when nested; otherwise fall back to the root swap.
+      const parent = navigation.getParent()
+      if (parent) {
+        parent.navigate('WalletList' as never)
+      } else {
+        goHome()
+      }
     } else {
       navigation.navigate('VaultSetup')
     }

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -21,6 +21,7 @@ import RocketWithGlow from 'components/migration/RocketWithGlow'
 import PrimaryBackground from 'components/PrimaryBackground'
 import {
   discoverLegacyWallets,
+  getVaultKind,
   MigrationWallet,
 } from 'services/migrateToVault'
 import { getWallets } from 'utils/wallet'
@@ -63,9 +64,17 @@ export default function MigrationHome(): React.ReactElement {
 
   useEffect(() => {
     Promise.all([discoverLegacyWallets(), getWallets()])
-      .then(([found, all]) => {
+      .then(async ([found, all]) => {
         setWallets(found)
-        setTotalWalletCount(all.length)
+        // `all` includes legacy AD-only entries that haven't been migrated to
+        // a fast vault yet — those are NOT "vaults" from the user's POV, only
+        // legacy seeds awaiting migration. Count only entries with a stored
+        // DKLS vault proto (i.e. getVaultKind returns 'fast' or 'multi-share').
+        const kinds = await Promise.all(
+          all.map((w) => getVaultKind(w.name))
+        )
+        const realVaultCount = kinds.filter((k) => k !== 'none').length
+        setTotalWalletCount(realVaultCount)
         setReady(true)
       })
       .catch(() => {

--- a/src/screens/migration/VerifyEmail.tsx
+++ b/src/screens/migration/VerifyEmail.tsx
@@ -105,11 +105,11 @@ export default function VerifyEmail(): React.ReactElement {
       // earlier point leaves the legacy wallet recoverable.
       try {
         await storeFastVault(walletName, keyImportResult)
-        // The isFastVault status for this wallet just flipped from
-        // false -> true. Invalidate the cached query so WalletList
-        // re-renders the migrated wallet with the correct CTA instead
-        // of still offering "Migrate to a vault".
-        queryClient.invalidateQueries(['isFastVault', walletName])
+        // The vault kind for this wallet just flipped from "none" to
+        // "fast". Invalidate the cached query so WalletList re-renders
+        // the migrated wallet with the correct CTA instead of still
+        // offering "Migrate to a vault".
+        queryClient.invalidateQueries(['vaultKind', walletName])
       } catch (err) {
         // Vault activation succeeded on the server but local persistence
         // failed. The legacy key is still on-device, so the user isn't

--- a/src/services/migrateToVault.ts
+++ b/src/services/migrateToVault.ts
@@ -42,7 +42,19 @@ export interface MigrationResult {
 }
 
 /**
- * Reads legacy auth data and returns the list of wallets available for migration.
+ * Reads legacy auth data and returns only wallets that still have key
+ * material to migrate (i.e. have not yet been migrated / imported / created
+ * as a vault).
+ *
+ * After migration or vault creation, `storeFastVault` / `persistImportedVault`
+ * zero out `encryptedKey` in the authData entry but leave the entry in place
+ * so that `getWallets()` can still find the wallet. We must filter those
+ * already-migrated stubs out here so that they do not drive the "Start
+ * Migration" CTA after the user has finished migrating.
+ *
+ * An entry is considered unmigrated when:
+ *   - it is a Ledger wallet (`ledger === true`), OR
+ *   - it still has a non-empty `encryptedKey`
  */
 export async function discoverLegacyWallets(): Promise<
   MigrationWallet[]
@@ -50,15 +62,20 @@ export async function discoverLegacyWallets(): Promise<
   const authData = await getAuthData()
   if (!authData) return []
 
-  return Object.entries(authData).map(([name, data]) => ({
-    name,
-    address: data.address,
-    ledger: data.ledger === true,
-    path:
-      data.ledger === true
-        ? (data as LedgerDataValueType).path
-        : undefined,
-  }))
+  return Object.entries(authData)
+    .filter(([, data]) => {
+      if (data.ledger === true) return true
+      return (data as AuthDataValueType).encryptedKey?.length > 0
+    })
+    .map(([name, data]) => ({
+      name,
+      address: data.address,
+      ledger: data.ledger === true,
+      path:
+        data.ledger === true
+          ? (data as LedgerDataValueType).path
+          : undefined,
+    }))
 }
 
 /**
@@ -157,19 +174,51 @@ export async function storeFastVault(
 }
 
 /**
- * Check if a stored vault is a DKLS fast vault (vs legacy KEYIMPORT).
+ * Canonical vault classifier — mirrors iOS `Vault.swift:172` and
+ * vultiagent-app `vaultUtils.ts:6`.
+ *
+ * - 'none'        → no stored vault proto for this wallet
+ * - 'fast'        → DKLS vault, has a `server-`-prefixed signer, and the
+ *                   user's own localPartyId is NOT server-prefixed (i.e. a
+ *                   2-of-2 device + VultiServer vault)
+ * - 'multi-share' → DKLS vault with no server signer (multi-device, or the
+ *                   device is itself the server party — shouldn't self-classify
+ *                   as fast)
+ */
+export async function getVaultKind(
+  walletName: string
+): Promise<'none' | 'fast' | 'multi-share'> {
+  const stored = await getStoredVault(walletName)
+  if (!stored) return 'none'
+  try {
+    const decoded = fromBinary(VaultSchema, base64.decode(stored))
+    if (decoded.libType !== LibType.DKLS) return 'multi-share'
+    // localPartyId is server-side → not a fast vault from user perspective
+    if (decoded.localPartyId?.toLowerCase().startsWith('server-')) {
+      return 'multi-share'
+    }
+    const hasServerSigner = decoded.signers.some((s) =>
+      s.toLowerCase().startsWith('server-')
+    )
+    return hasServerSigner ? 'fast' : 'multi-share'
+  } catch {
+    return 'none'
+  }
+}
+
+/**
+ * Check if a stored vault is a DKLS fast vault (vs legacy KEYIMPORT or
+ * multi-share).  Uses the canonical server-prefix discriminator from iOS
+ * `Vault.swift:172` and vultiagent-app `vaultUtils.ts:6`: a fast vault has at
+ * least one `server-`-prefixed signer AND the user's own localPartyId is NOT
+ * server-prefixed.
+ *
+ * Note: still called by ExportPrivateKey.tsx — see open follow-up ticket.
  */
 export async function isVaultFastVault(
   walletName: string
 ): Promise<boolean> {
-  const stored = await getStoredVault(walletName)
-  if (!stored) return false
-  try {
-    const decoded = fromBinary(VaultSchema, base64.decode(stored))
-    return decoded.libType === LibType.DKLS
-  } catch {
-    return false
-  }
+  return (await getVaultKind(walletName)) === 'fast'
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Fix 1 — Multi-share vault label**: Multi-share vaults imported via the share-file flow were incorrectly labeled "Fast Vault" because `isVaultFastVault` used `libType === DKLS` as the sole discriminator. A 3-of-3 vault from the desktop client has `libType: DKLS` but no `server-` signer, so it was misclassified. Fixed by aligning with the canonical discriminator from iOS `Vault.swift:172` and vultiagent-app `vaultUtils.ts:6`: a vault is "fast" when it has a `server-`-prefixed signer AND the user's own `localPartyId` is not server-prefixed. Adds `getVaultKind()` returning `'none' | 'fast' | 'multi-share'`; `WalletCard` now takes `vaultKind` prop instead of `isFastVault: boolean`. Multi-share vaults render a shield chip labeled "Vault" instead of the lightning "Fast Vault" chip.

- **Fix 2 — Post-migration CTA copy**: After migrating or creating vaults, `MigrationHome`'s primary CTA still showed "Start Migration" because `discoverLegacyWallets()` returned all authData entries including already-migrated stubs (entries where `storeFastVault`/`persistImportedVault` had zeroed the `encryptedKey`). Fixed by filtering `discoverLegacyWallets` to only entries that still have key material (`encryptedKey.length > 0` or `ledger: true`). `MigrationHome` now reads both unmigrated-legacy count and total-vault count to render a 3-state CTA: "Start Migration" (first-time), "Continue migration" (mixed), or "See my vaults" (fully migrated).

Spike doc: `.spikes/station-mobile-ux-fixes-fast-vault-label-and-cta-2026-05-07.md`

## Before / After

**Fix 1:**
- Before: importing a 3-of-3 multi-device `.vult` share file → WalletList card showed lightning bolt + "Fast Vault" chip (incorrect; this vault cannot use VultiServer keysign).
- After: same import → card shows shield icon + "Vault" chip. Fast-vault imports (2-of-2 with VultiServer) still show "Fast Vault" unchanged.

**Fix 2:**
- Before: a user who had migrated all their legacy wallets and then navigated WalletList → back → MigrationHome would see "Start Migration" as the primary CTA.
- After: same scenario → CTA reads "See my vaults" and tapping it navigates to WalletList via `goHome()`. Mixed state (some migrated, some still legacy) shows "Continue migration". Fresh-install state still shows "Create a Fast Vault" (unchanged).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 126 tests pass (15 suites), including:
  - `__tests__/wallet/vault-kind.test.ts` — all 6 vault-kind classification cases
  - `__tests__/migration/discover-legacy-wallets.test.ts` — all 5 filter cases
- [x] `npm run lint` — clean (0 errors, 0 warnings introduced by this PR)
- [ ] Manual verify on physical phone — owner: human reviewer
  - Import a 3-of-3 vault share → WalletList should show "Vault" chip, not "Fast Vault"
  - Migrate a legacy seed → WalletList → back → MigrationHome should show "See my vaults"
  - Mixed state (one migrated, one legacy) → MigrationHome should show "Continue migration"
  - Fast vault (2-of-2 with VultiServer) → still shows "Fast Vault" chip
  
## Receipts
<img width="1200" height="2670" alt="image" src="https://github.com/user-attachments/assets/639e315a-5b6b-4ef8-812e-7d997894d267" />
<img width="1200" height="2670" alt="image" src="https://github.com/user-attachments/assets/a4025b61-0aff-4d58-bccb-0dc1824add58" />
<img width="1200" height="2670" alt="image" src="https://github.com/user-attachments/assets/7de74e75-8c46-4d09-b490-a64b94282a7b" />
<img width="1200" height="2670" alt="image" src="https://github.com/user-attachments/assets/5c549dd7-8cc9-4b8c-afe8-3d0c6ee60143" />
<img width="1200" height="2670" alt="image" src="https://github.com/user-attachments/assets/93491be9-3478-4a27-b591-e7be049e66c2" />


## Out of scope (worth follow-up tickets)

- `AuthMenu.tsx:84` "Import Fast Vault" copy — slightly misleading for multi-share imports (pre-existing; not introduced by this PR).
- `ExportPrivateKey.tsx:46-110` multi-share branch — when `isFastVault` returns false for a multi-share vault, the screen falls into the legacy-keystore PK path which will fail to find a PK. Needs a third branch (vault-share download). Pre-existing gap made visible by Fix 1; separate ticket needed.

🤖 Agent-generated