### PR TITLE
Fix vault share export copy

### DIFF
--- a/__tests__/vault/share-export.test.ts
+++ b/__tests__/vault/share-export.test.ts
@@ -4,11 +4,18 @@ import { base64 } from '@scure/base'
 import { VaultSchema } from '../../src/proto/vultisig/vault/v1/vault_pb'
 import { VaultContainerSchema } from '../../src/proto/vultisig/vault/v1/vault_container_pb'
 import { LibType } from '../../src/proto/vultisig/keygen/v1/lib_type_message_pb'
-import { buildVaultProto, derivePublicKeyHex } from 'services/vaultProto'
-import { encryptWithPassword, decryptVaultBytes } from 'services/vaultCrypto'
+import {
+  buildVaultProto,
+  derivePublicKeyHex,
+} from 'services/vaultProto'
+import {
+  encryptWithPassword,
+  decryptVaultBytes,
+} from 'services/vaultCrypto'
 import { getExportWarning } from 'utils/exportWarning'
 
-const PK = '0000000000000000000000000000000000000000000000000000000000000001'
+const PK =
+  '0000000000000000000000000000000000000000000000000000000000000001'
 const EXPECTED_PUB =
   '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
 const DETERMINISTIC_NONCE = new Uint8Array(12).fill(7)
@@ -28,13 +35,17 @@ describe('vault share export — .vult round-trip', () => {
   })
 
   it('serializes + encrypts + decrypts + parses back to identical fields', () => {
-    const vaultProto = buildVaultProto('TestWallet1', EXPECTED_PUB, PK)
+    const vaultProto = buildVaultProto(
+      'TestWallet1',
+      EXPECTED_PUB,
+      PK
+    )
     const vaultBytes = toBinary(VaultSchema, vaultProto)
 
     const encrypted = encryptWithPassword(
       vaultBytes,
       'exportpass',
-      DETERMINISTIC_NONCE,
+      DETERMINISTIC_NONCE
     )
     const container = create(VaultContainerSchema, {
       version: 1n,
@@ -43,13 +54,16 @@ describe('vault share export — .vult round-trip', () => {
     })
     const containerBytes = toBinary(VaultContainerSchema, container)
 
-    const parsedContainer = fromBinary(VaultContainerSchema, containerBytes)
+    const parsedContainer = fromBinary(
+      VaultContainerSchema,
+      containerBytes
+    )
     expect(parsedContainer.isEncrypted).toBe(true)
     expect(parsedContainer.version).toBe(1n)
 
     const decryptedVault = decryptVaultBytes(
       base64.decode(parsedContainer.vault),
-      'exportpass',
+      'exportpass'
     )
     const roundTripped = fromBinary(VaultSchema, decryptedVault)
     expect(roundTripped.name).toBe('TestWallet1')
@@ -60,23 +74,25 @@ describe('vault share export — .vult round-trip', () => {
 })
 
 describe('getExportWarning — 3-branch copy', () => {
-  it("fast vault: warns that share + password is enough to drain funds", () => {
+  it('fast vault: warns that the share alone gives funds access (mirrors private-key copy)', () => {
     const w = getExportWarning('fast')
-    expect(w).toContain('your password')
-    expect(w).toContain('drain your funds')
+    expect(w).toContain(
+      'Anyone with this key share can access your funds'
+    )
+    expect(w).toContain('Never share it')
   })
 
-  it("multi-share vault: reassures that a single share cannot access the vault alone", () => {
+  it('multi-share vault: reassures that a single share cannot access the vault alone', () => {
     const w = getExportWarning('multi-share')
     expect(w).toContain('cannot access a Secure Vault by itself')
   })
 
-  it("none (legacy private key): warns that anyone with the key has full access", () => {
+  it('none (legacy private key): warns that anyone with the key has full access', () => {
     const w = getExportWarning('none')
     expect(w).toContain('Anyone with this key can access your funds')
   })
 
-  it("loading state (null): defaults to the optimistic share-safe copy", () => {
+  it('loading state (null): defaults to the optimistic share-safe copy', () => {
     const w = getExportWarning(null)
     expect(w).toContain('cannot access a Secure Vault by itself')
   })

--- a/__tests__/vault/share-export.test.ts
+++ b/__tests__/vault/share-export.test.ts
@@ -6,6 +6,7 @@ import { VaultContainerSchema } from '../../src/proto/vultisig/vault/v1/vault_co
 import { LibType } from '../../src/proto/vultisig/keygen/v1/lib_type_message_pb'
 import { buildVaultProto, derivePublicKeyHex } from 'services/vaultProto'
 import { encryptWithPassword, decryptVaultBytes } from 'services/vaultCrypto'
+import { getExportWarning } from 'utils/exportWarning'
 
 const PK = '0000000000000000000000000000000000000000000000000000000000000001'
 const EXPECTED_PUB =
@@ -55,5 +56,28 @@ describe('vault share export — .vult round-trip', () => {
     expect(roundTripped.publicKeyEcdsa).toBe(EXPECTED_PUB)
     expect(roundTripped.libType).toBe(LibType.KEYIMPORT)
     expect(roundTripped.keyShares[0].keyshare).toBe(PK)
+  })
+})
+
+describe('getExportWarning — 3-branch copy', () => {
+  it("fast vault: warns that share + password is enough to drain funds", () => {
+    const w = getExportWarning('fast')
+    expect(w).toContain('your password')
+    expect(w).toContain('drain your funds')
+  })
+
+  it("multi-share vault: reassures that a single share cannot access the vault alone", () => {
+    const w = getExportWarning('multi-share')
+    expect(w).toContain('cannot access a Secure Vault by itself')
+  })
+
+  it("none (legacy private key): warns that anyone with the key has full access", () => {
+    const w = getExportWarning('none')
+    expect(w).toContain('Anyone with this key can access your funds')
+  })
+
+  it("loading state (null): defaults to the optimistic share-safe copy", () => {
+    const w = getExportWarning(null)
+    expect(w).toContain('cannot access a Secure Vault by itself')
   })
 })

--- a/src/screens/ExportPrivateKey.tsx
+++ b/src/screens/ExportPrivateKey.tsx
@@ -23,6 +23,7 @@ import Button from 'components/Button'
 import MigrationToolbar from 'components/migration/MigrationToolbar'
 import { formStyles } from 'components/migration/migrationStyles'
 import { COLORS, MONO_FONT } from 'consts/theme'
+import { getExportWarning } from 'utils/exportWarning'
 
 import type { MainStackParams } from 'navigation/MainNavigator'
 
@@ -100,9 +101,7 @@ export default function ExportPrivateKey(): React.ReactElement {
   const title = shouldShowVaultShareCopy
     ? 'Export Vault Share'
     : 'Export Private Key'
-  const warning = shouldShowVaultShareCopy
-    ? 'A single encrypted vault share cannot access a Secure Vault by itself. Keep it private and share it only with people you trust.'
-    : 'Anyone with this key can access your funds. Never share it.'
+  const warning = getExportWarning(vaultKind)
 
   const handleExportVaultShare =
     useCallback(async (): Promise<void> => {

--- a/src/screens/ExportPrivateKey.tsx
+++ b/src/screens/ExportPrivateKey.tsx
@@ -17,7 +17,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { getDecyrptedKey } from 'utils/wallet'
 import { exportVaultShare } from 'services/exportVaultShare'
 import VaultSharing from '../../modules/vault-sharing'
-import { isVaultFastVault } from 'services/migrateToVault'
+import { getVaultKind } from 'services/migrateToVault'
 import Text from 'components/Text'
 import Button from 'components/Button'
 import MigrationToolbar from 'components/migration/MigrationToolbar'
@@ -43,14 +43,22 @@ export default function ExportPrivateKey(): React.ReactElement {
   const [exporting, setExporting] = useState(false)
   const [exportError, setExportError] = useState('')
 
-  const [isFastVault, setIsFastVault] = useState(false)
+  const [vaultKind, setVaultKind] = useState<Awaited<
+    ReturnType<typeof getVaultKind>
+  > | null>(null)
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined
   )
 
   useEffect(() => {
-    isVaultFastVault(wallet.name).then(setIsFastVault)
+    let cancelled = false
+    getVaultKind(wallet.name).then((kind) => {
+      if (!cancelled) setVaultKind(kind)
+    })
+    return (): void => {
+      cancelled = true
+    }
   }, [wallet.name])
 
   useEffect(() => {
@@ -84,17 +92,29 @@ export default function ExportPrivateKey(): React.ReactElement {
     timerRef.current = setTimeout(() => setCopied(false), 2000)
   }, [privateKey])
 
+  const isVaultKindLoaded = vaultKind !== null
+  const isVaultShareExport =
+    vaultKind === 'fast' || vaultKind === 'multi-share'
+  const shouldShowVaultShareCopy =
+    !isVaultKindLoaded || isVaultShareExport
+  const title = shouldShowVaultShareCopy
+    ? 'Export Vault Share'
+    : 'Export Private Key'
+  const warning = shouldShowVaultShareCopy
+    ? 'A single encrypted vault share cannot access a Secure Vault by itself. Keep it private and share it only with people you trust.'
+    : 'Anyone with this key can access your funds. Never share it.'
+
   const handleExportVaultShare =
     useCallback(async (): Promise<void> => {
       if (exportPassword.length === 0) return
-      if (!isFastVault && !privateKey) return
+      if (!isVaultShareExport && !privateKey) return
       setExporting(true)
       setExportError('')
       try {
         const fileUri = await exportVaultShare(
           wallet.name,
           exportPassword,
-          isFastVault ? undefined : privateKey ?? undefined
+          isVaultShareExport ? undefined : privateKey ?? undefined
         )
         await VaultSharing.shareAsync(fileUri)
         setShowExportForm(false)
@@ -107,7 +127,7 @@ export default function ExportPrivateKey(): React.ReactElement {
       } finally {
         setExporting(false)
       }
-    }, [isFastVault, privateKey, wallet.name, exportPassword])
+    }, [isVaultShareExport, privateKey, wallet.name, exportPassword])
 
   // Pick the primary CTA for the current state. The footer only ever
   // shows one primary button at a time, sticky to the bottom of the
@@ -119,18 +139,20 @@ export default function ExportPrivateKey(): React.ReactElement {
     testID?: string
   }
   let primary: Cta | null = null
-  if (!isFastVault && !privateKey) {
+  if (!isVaultKindLoaded) {
+    primary = null
+  } else if (!isVaultShareExport && !privateKey) {
     primary = {
       title: 'Reveal Private Key',
       onPress: handleReveal,
       disabled: password.length === 0,
     }
-  } else if (!isFastVault && privateKey && !showExportForm) {
+  } else if (!isVaultShareExport && privateKey && !showExportForm) {
     primary = {
       title: copied ? 'Copied!' : 'Copy to Clipboard',
       onPress: handleCopy,
     }
-  } else if ((isFastVault || privateKey) && !showExportForm) {
+  } else if ((isVaultShareExport || privateKey) && !showExportForm) {
     primary = {
       title: 'Export as Vault Share',
       onPress: (): void => setShowExportForm(true),
@@ -156,18 +178,15 @@ export default function ExportPrivateKey(): React.ReactElement {
         contentContainerStyle={styles.content}
         keyboardShouldPersistTaps="handled"
       >
-        <Text style={styles.title}>Export Private Key</Text>
+        <Text style={styles.title}>{title}</Text>
         <Text style={styles.walletName}>{wallet.name}</Text>
         <Text style={styles.address}>{wallet.address}</Text>
 
         <View style={styles.warningCard}>
-          <Text style={styles.warningText}>
-            Anyone with this key can access your funds. Never share
-            it.
-          </Text>
+          <Text style={styles.warningText}>{warning}</Text>
         </View>
 
-        {!isFastVault && !privateKey && (
+        {isVaultKindLoaded && !isVaultShareExport && !privateKey && (
           <>
             <TextInput
               style={styles.input}
@@ -184,7 +203,7 @@ export default function ExportPrivateKey(): React.ReactElement {
           </>
         )}
 
-        {!isFastVault && privateKey && (
+        {!isVaultShareExport && privateKey && (
           <>
             <View style={styles.qrContainer}>
               <QRCode

--- a/src/utils/exportWarning.ts
+++ b/src/utils/exportWarning.ts
@@ -6,8 +6,9 @@ type VaultKind = Awaited<ReturnType<typeof getVaultKind>>
  * Pick the warning copy shown above the export form.
  *
  * Three real branches once the vault kind has loaded:
- *   - 'fast'        → recoverable-by-itself: anyone with the share + password
- *                     can sign and drain. Treat it like a private key.
+ *   - 'fast'        → recoverable-by-itself: VultiServer's share is reachable
+ *                     with just the password, so anyone with this share can
+ *                     drain. Mirrors the legacy private-key warning.
  *   - 'multi-share' → a single encrypted share cannot access the vault alone.
  *   - 'none'        → legacy AD-only wallet: this really is a raw private key.
  *
@@ -18,7 +19,7 @@ export function getExportWarning(
   vaultKind: VaultKind | null
 ): string {
   if (vaultKind === 'fast') {
-    return 'Anyone with this vault share and your password can sign transactions and drain your funds. Treat it like a private key.'
+    return 'Anyone with this key share can access your funds. Never share it.'
   }
   if (vaultKind === 'none') {
     return 'Anyone with this key can access your funds. Never share it.'

--- a/src/utils/exportWarning.ts
+++ b/src/utils/exportWarning.ts
@@ -1,0 +1,28 @@
+import type { getVaultKind } from 'services/migrateToVault'
+
+type VaultKind = Awaited<ReturnType<typeof getVaultKind>>
+
+/**
+ * Pick the warning copy shown above the export form.
+ *
+ * Three real branches once the vault kind has loaded:
+ *   - 'fast'        → recoverable-by-itself: anyone with the share + password
+ *                     can sign and drain. Treat it like a private key.
+ *   - 'multi-share' → a single encrypted share cannot access the vault alone.
+ *   - 'none'        → legacy AD-only wallet: this really is a raw private key.
+ *
+ * While the kind is still loading (`null`) we default to the optimistic
+ * share-safe copy — the warning card flips once `getVaultKind` resolves.
+ */
+export function getExportWarning(
+  vaultKind: VaultKind | null
+): string {
+  if (vaultKind === 'fast') {
+    return 'Anyone with this vault share and your password can sign transactions and drain your funds. Treat it like a private key.'
+  }
+  if (vaultKind === 'none') {
+    return 'Anyone with this key can access your funds. Never share it.'
+  }
+  // 'multi-share' or still loading (null) — optimistic safe-to-share default
+  return 'A single encrypted vault share cannot access a Secure Vault by itself. Keep it private and share it only with people you trust.'
+}


### PR DESCRIPTION
## Description

Updates the Station export screen copy for stored vaults.

- Shows `Export Vault Share` for fast and multi-share vault exports.
- Replaces the private-key warning with vault-share-specific copy.
- Keeps the legacy private-key export copy for wallets without a stored vault.

## Verification

- `npm run typecheck`
- `npx eslint src/screens/ExportPrivateKey.tsx`
- `npm test -- --runInBand __tests__/wallet/vault-kind.test.ts __tests__/vault/share-export.test.ts`
- Built and opened on a dedicated iOS simulator: `Station Export Share Fix` (`0B551454-3646-4FD6-8B82-AF194EE5A8A5`)

## Screenshots

Before (main), after (this branch)

<img width="900" height="961" alt="Screenshot 2026-05-08 at 4 22 21 pm" src="https://github.com/user-attachments/assets/96bdf3bb-b543-4a63-af5f-60727f6dce77" />
