### PR TITLE
Fix Vultisig-compatible Station vault derivation

### DIFF
--- a/__tests__/__mocks__/expo-file-system-legacy.ts
+++ b/__tests__/__mocks__/expo-file-system-legacy.ts
@@ -1,0 +1,22 @@
+const files = new Map<string, string>()
+
+export const cacheDirectory = 'file:///tmp/station-mobile-cache/'
+
+export async function writeAsStringAsync(
+  uri: string,
+  contents: string
+): Promise<void> {
+  files.set(uri, contents)
+}
+
+export async function readAsStringAsync(uri: string): Promise<string> {
+  const contents = files.get(uri)
+  if (contents === undefined) {
+    throw new Error(`File not found: ${uri}`)
+  }
+  return contents
+}
+
+export function __reset(): void {
+  files.clear()
+}

--- a/__tests__/services/fast-vault-server.test.ts
+++ b/__tests__/services/fast-vault-server.test.ts
@@ -1,0 +1,121 @@
+import {
+  setupBatchImport,
+  setupBatchKeygen,
+  setupKeyImport,
+} from 'services/fastVaultServer'
+
+describe('fastVaultServer batch setup payloads', () => {
+  let fetchMock: jest.Mock
+
+  beforeEach(() => {
+    fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(''),
+    })
+    ;(globalThis as unknown as { fetch: jest.Mock }).fetch = fetchMock
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('posts Vultisig-style batch keygen payloads for created fast vaults', async () => {
+    await setupBatchKeygen({
+      name: 'CreatedFastVault',
+      session_id: 'session',
+      hex_encryption_key: 'encryption',
+      hex_chain_code: 'chain-code',
+      local_party_id: 'Server',
+      encryption_password: 'password',
+      email: 'user@example.com',
+      lib_type: 1,
+      protocols: ['ecdsa', 'eddsa'],
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.vultisig.com/vault/batch/keygen',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'CreatedFastVault',
+          session_id: 'session',
+          hex_encryption_key: 'encryption',
+          hex_chain_code: 'chain-code',
+          local_party_id: 'Server',
+          encryption_password: 'password',
+          email: 'user@example.com',
+          lib_type: 1,
+          protocols: ['ecdsa', 'eddsa'],
+        }),
+      }
+    )
+  })
+
+  it('posts seed import payloads without the old Station hex_chain_code field', async () => {
+    await setupBatchImport({
+      name: 'SeedImport',
+      session_id: 'session',
+      hex_encryption_key: 'encryption',
+      local_party_id: 'Server',
+      encryption_password: 'password',
+      email: 'user@example.com',
+      lib_type: 2,
+      protocols: ['ecdsa', 'eddsa'],
+      chains: ['Ethereum', 'Terra', 'Solana'],
+    })
+
+    const request = fetchMock.mock.calls[0][1]
+    const body = JSON.parse(request.body)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.vultisig.com/vault/batch/import',
+      expect.any(Object)
+    )
+    expect(body).toEqual({
+      name: 'SeedImport',
+      session_id: 'session',
+      hex_encryption_key: 'encryption',
+      local_party_id: 'Server',
+      encryption_password: 'password',
+      email: 'user@example.com',
+      lib_type: 2,
+      protocols: ['ecdsa', 'eddsa'],
+      chains: ['Ethereum', 'Terra', 'Solana'],
+    })
+    expect(body.hex_chain_code).toBeUndefined()
+  })
+
+  it('posts sequential key import payloads with the seed root chain code', async () => {
+    await setupKeyImport({
+      name: 'SeedImport',
+      session_id: 'session',
+      hex_encryption_key: 'encryption',
+      hex_chain_code: 'root-chain-code',
+      local_party_id: 'Server',
+      encryption_password: 'password',
+      email: 'user@example.com',
+      lib_type: 2,
+      chains: ['Ethereum', 'Terra'],
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.vultisig.com/vault/import',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'SeedImport',
+          session_id: 'session',
+          hex_encryption_key: 'encryption',
+          hex_chain_code: 'root-chain-code',
+          local_party_id: 'Server',
+          encryption_password: 'password',
+          email: 'user@example.com',
+          lib_type: 2,
+          chains: ['Ethereum', 'Terra'],
+        }),
+      }
+    )
+  })
+})

--- a/__tests__/vault/share-export.test.ts
+++ b/__tests__/vault/share-export.test.ts
@@ -1,16 +1,26 @@
 import { create, toBinary, fromBinary } from '@bufbuild/protobuf'
 import { base64 } from '@scure/base'
+import { readAsStringAsync } from 'expo-file-system/legacy'
 
+import { __reset as resetFileSystem } from '../__mocks__/expo-file-system-legacy'
+import { __reset as resetSecure } from '../__mocks__/expo-secure-store'
 import { VaultSchema } from '../../src/proto/vultisig/vault/v1/vault_pb'
 import { VaultContainerSchema } from '../../src/proto/vultisig/vault/v1/vault_container_pb'
 import { LibType } from '../../src/proto/vultisig/keygen/v1/lib_type_message_pb'
 import { buildVaultProto, derivePublicKeyHex } from 'services/vaultProto'
 import { encryptWithPassword, decryptVaultBytes } from 'services/vaultCrypto'
+import { storeFastVault } from 'services/migrateToVault'
+import { exportVaultShare } from 'services/exportVaultShare'
 
 const PK = '0000000000000000000000000000000000000000000000000000000000000001'
 const EXPECTED_PUB =
   '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
 const DETERMINISTIC_NONCE = new Uint8Array(12).fill(7)
+
+beforeEach(() => {
+  resetSecure()
+  resetFileSystem()
+})
 
 describe('vault share export — .vult round-trip', () => {
   it('derives the correct pubkey from the test private key', () => {
@@ -55,5 +65,47 @@ describe('vault share export — .vult round-trip', () => {
     expect(roundTripped.publicKeyEcdsa).toBe(EXPECTED_PUB)
     expect(roundTripped.libType).toBe(LibType.KEYIMPORT)
     expect(roundTripped.keyShares[0].keyshare).toBe(PK)
+  })
+
+  it('exports stored Terra KEYIMPORT MPC vaults directly without a raw private key', async () => {
+    await storeFastVault('MigratedTerra', {
+      publicKey: EXPECTED_PUB,
+      keyshare: 'mpc-terra-share',
+      chainCode: '0'.repeat(64),
+      localPartyId: 'Device',
+      serverPartyId: 'Server',
+    })
+
+    const fileUri = await exportVaultShare('MigratedTerra', null)
+    const containerBase64 = await readAsStringAsync(fileUri)
+    const container = fromBinary(
+      VaultContainerSchema,
+      base64.decode(containerBase64)
+    )
+    const exportedVault = fromBinary(
+      VaultSchema,
+      base64.decode(container.vault)
+    )
+
+    expect(container.isEncrypted).toBe(false)
+    expect(exportedVault.libType).toBe(LibType.KEYIMPORT)
+    expect(exportedVault.publicKeyEcdsa).toBe(EXPECTED_PUB)
+    expect(exportedVault.hexChainCode).toBe('')
+    expect(exportedVault.keyShares[0].keyshare).toBe('mpc-terra-share')
+    expect(
+      exportedVault.chainPublicKeys.map(
+        ({ chain, publicKey, isEddsa }) => ({
+          chain,
+          publicKey,
+          isEddsa,
+        })
+      )
+    ).toEqual([
+      {
+        chain: 'Terra',
+        publicKey: EXPECTED_PUB,
+        isEddsa: false,
+      },
+    ])
   })
 })

--- a/__tests__/wallet/private-key-import.test.ts
+++ b/__tests__/wallet/private-key-import.test.ts
@@ -1,0 +1,41 @@
+import {
+  normalizePrivateKey,
+  validatePrivateKey,
+} from 'services/privateKeyImport'
+
+describe('private key import validation', () => {
+  const privateKey =
+    '0000000000000000000000000000000000000000000000000000000000000002'
+
+  it('normalizes 0x-prefixed private keys with whitespace', () => {
+    expect(
+      normalizePrivateKey(
+        `  0x${privateKey.slice(0, 32)}  ${privateKey.slice(32)}  `
+      )
+    ).toBe(privateKey)
+  })
+
+  it('derives the Terra address for a valid private key', () => {
+    const result = validatePrivateKey(privateKey)
+
+    expect(result.privateKeyHex).toBe(privateKey)
+    expect(result.publicKeyHex).toBe(
+      '02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5'
+    )
+    expect(result.terraAddress).toBe(
+      'terra1q6hag67dl53wl99vzg42z8eyzfz2xlkvk8uu5v'
+    )
+  })
+
+  it('rejects malformed private keys', () => {
+    expect(() => validatePrivateKey('not-a-key')).toThrow(
+      /64 hexadecimal/i
+    )
+  })
+
+  it('rejects invalid secp256k1 private keys', () => {
+    expect(() => validatePrivateKey('0'.repeat(64))).toThrow(
+      /Invalid secp256k1/i
+    )
+  })
+})

--- a/__tests__/wallet/seed-phrase-import.test.ts
+++ b/__tests__/wallet/seed-phrase-import.test.ts
@@ -1,0 +1,80 @@
+import {
+  deriveChainKey,
+  deriveMasterKeys,
+  SEED_IMPORT_DERIVATION_GROUPS,
+  validateSeedPhrase,
+} from 'services/seedPhraseImport'
+
+const TREZOR_12 =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+
+describe('seed phrase import derivation', () => {
+  it('validates BIP39 mnemonics', () => {
+    expect(validateSeedPhrase(TREZOR_12)).toBe(true)
+    expect(validateSeedPhrase(TREZOR_12.replace(/about$/, 'abandon'))).toBe(
+      false
+    )
+  })
+
+  it('derives Vultisig-compatible root keys from the Trezor vector', () => {
+    const keys = deriveMasterKeys(TREZOR_12)
+    expect(keys.ecdsaPrivateKey).toBe(
+      '1837c1be8e2995ec11cda2b066151be2cfb48adf9e47b151d46adab3a21cdf67'
+    )
+    expect(keys.ecdsaChainCode).toBe(
+      '7923408dadd3c7b56eed15567707ae5e5dca089de972e07f3b860450e2a3b70e'
+    )
+    expect(keys.eddsaPrivateKey).toBe(
+      '1f303fc1a855ef1f4f26907b6c8f948fb4c29777bfdac547fd1b48df39714405'
+    )
+  })
+
+  it("derives Terra at m/44'/330'/0'/0/0", () => {
+    const key = deriveChainKey(TREZOR_12, 'Terra')
+    expect(key.isEddsa).toBe(false)
+    expect(key.privateKey).toBe(
+      '05be413bb5bd1fb67757251976dd43adf0d4db27d1a5444b4f6ef754ef939b10'
+    )
+    expect(key.chainCode).toBe(
+      'ae72963c7ca2245c53899c93b2e1a1ff4f08fe6e9a6071a31c30d798f1a1ac8f'
+    )
+  })
+
+  it('imports each Vultisig-supported seed chain as its own batch chain', () => {
+    expect(SEED_IMPORT_DERIVATION_GROUPS).toHaveLength(36)
+    expect(
+      SEED_IMPORT_DERIVATION_GROUPS.every(
+        (group) =>
+          group.chains.length === 1 &&
+          group.chains[0] === group.representativeChain
+      )
+    ).toBe(true)
+    expect(
+      SEED_IMPORT_DERIVATION_GROUPS.map(
+        (group) => group.representativeChain
+      )
+    ).toEqual(
+      expect.arrayContaining([
+        'Bitcoin',
+        'Ethereum',
+        'BSC',
+        'THORChain',
+        'MayaChain',
+        'Terra',
+        'TerraClassic',
+        'Solana',
+        'Sui',
+        'Ton',
+        'Polkadot',
+        'Bittensor',
+        'Ripple',
+        'Tron',
+      ])
+    )
+    expect(
+      SEED_IMPORT_DERIVATION_GROUPS.filter((group) => group.isEddsa).map(
+        (group) => group.representativeChain
+      )
+    ).toEqual(['Solana', 'Sui', 'Ton', 'Polkadot', 'Bittensor'])
+  })
+})

--- a/__tests__/wallet/vault-store.test.ts
+++ b/__tests__/wallet/vault-store.test.ts
@@ -3,7 +3,7 @@ import { base64 } from '@scure/base'
 
 import { __reset as resetSecure } from '../__mocks__/expo-secure-store'
 import { persistImportedVault } from 'services/importVaultBackup'
-import { getStoredVault } from 'services/migrateToVault'
+import { getStoredVault, storeFastVault } from 'services/migrateToVault'
 import { VaultSchema } from '../../src/proto/vultisig/vault/v1/vault_pb'
 import { LibType } from '../../src/proto/vultisig/keygen/v1/lib_type_message_pb'
 
@@ -59,5 +59,143 @@ describe('persistImportedVault → getStoredVault', () => {
     expect(stored).toBeTruthy()
     const restored = fromBinary(VaultSchema, base64.decode(stored!))
     expect(restored.name).toBe('My Weird/Vault!')
+  })
+})
+
+describe('storeFastVault', () => {
+  it('stores legacy/private-key migrations as Terra KEYIMPORT vaults', async () => {
+    await storeFastVault('TerraOnly', {
+      publicKey: '02terra',
+      keyshare: 'opaque-terra-share',
+      chainCode: '0'.repeat(64),
+      localPartyId: 'Device',
+      serverPartyId: 'Server',
+    })
+
+    const stored = await getStoredVault('TerraOnly')
+    expect(stored).toBeTruthy()
+
+    const restored = fromBinary(VaultSchema, base64.decode(stored!))
+    expect(restored.libType).toBe(LibType.KEYIMPORT)
+    expect(restored.publicKeyEcdsa).toBe('02terra')
+    expect(restored.publicKeyEddsa).toBe('')
+    expect(restored.hexChainCode).toBe('')
+    expect(
+      restored.keyShares.map(({ publicKey, keyshare }) => ({
+        publicKey,
+        keyshare,
+      }))
+    ).toEqual([
+      { publicKey: '02terra', keyshare: 'opaque-terra-share' },
+    ])
+    expect(
+      restored.chainPublicKeys.map(({ chain, publicKey, isEddsa }) => ({
+        chain,
+        publicKey,
+        isEddsa,
+      }))
+    ).toEqual([
+      { chain: 'Terra', publicKey: '02terra', isEddsa: false },
+    ])
+  })
+
+  it('stores newly created fast vaults as DKLS root ECDSA plus EdDSA vaults', async () => {
+    await storeFastVault('CreatedFastVault', {
+      publicKey: '02root',
+      publicKeyEcdsa: '02root',
+      publicKeyEddsa: 'edroot',
+      keyshareEcdsa: 'ecdsa-share',
+      keyshareEddsa: 'eddsa-share',
+      chainCode: '1'.repeat(64),
+      localPartyId: 'Device',
+      serverPartyId: 'Server',
+    })
+
+    const stored = await getStoredVault('CreatedFastVault')
+    expect(stored).toBeTruthy()
+
+    const restored = fromBinary(VaultSchema, base64.decode(stored!))
+    expect(restored.libType).toBe(LibType.DKLS)
+    expect(restored.publicKeyEcdsa).toBe('02root')
+    expect(restored.publicKeyEddsa).toBe('edroot')
+    expect(restored.hexChainCode).toBe('1'.repeat(64))
+    expect(restored.chainPublicKeys).toEqual([])
+    expect(
+      restored.keyShares.map(({ publicKey, keyshare }) => ({
+        publicKey,
+        keyshare,
+      }))
+    ).toEqual([
+      { publicKey: '02root', keyshare: 'ecdsa-share' },
+      { publicKey: 'edroot', keyshare: 'eddsa-share' },
+    ])
+  })
+
+  it('stores seed phrase imports as KeyImport root keys plus per-chain keys', async () => {
+    await storeFastVault('SeedImport', {
+      publicKey: '02root',
+      publicKeyEcdsa: '02root',
+      publicKeyEddsa: 'edroot',
+      keyshareEcdsa: 'root-ecdsa-share',
+      keyshareEddsa: 'root-eddsa-share',
+      chainCode: '2'.repeat(64),
+      localPartyId: 'Device',
+      serverPartyId: 'Server',
+      importedChains: [
+        {
+          chain: 'Ethereum',
+          publicKey: '02eth',
+          keyshare: 'eth-share',
+          isEddsa: false,
+        },
+        {
+          chain: 'Terra',
+          publicKey: '02terra',
+          keyshare: 'terra-share',
+          isEddsa: false,
+        },
+        {
+          chain: 'TerraClassic',
+          publicKey: '02terra',
+          keyshare: 'terra-share',
+          isEddsa: false,
+        },
+      ],
+    })
+
+    const stored = await getStoredVault('SeedImport')
+    expect(stored).toBeTruthy()
+
+    const restored = fromBinary(VaultSchema, base64.decode(stored!))
+    expect(restored.libType).toBe(LibType.KEYIMPORT)
+    expect(restored.publicKeyEcdsa).toBe('02root')
+    expect(restored.publicKeyEddsa).toBe('edroot')
+    expect(restored.hexChainCode).toBe('2'.repeat(64))
+    expect(
+      restored.chainPublicKeys.map(({ chain, publicKey, isEddsa }) => ({
+        chain,
+        publicKey,
+        isEddsa,
+      }))
+    ).toEqual([
+      { chain: 'Ethereum', publicKey: '02eth', isEddsa: false },
+      { chain: 'Terra', publicKey: '02terra', isEddsa: false },
+      {
+        chain: 'TerraClassic',
+        publicKey: '02terra',
+        isEddsa: false,
+      },
+    ])
+    expect(
+      restored.keyShares.map(({ publicKey, keyshare }) => ({
+        publicKey,
+        keyshare,
+      }))
+    ).toEqual([
+      { publicKey: '02root', keyshare: 'root-ecdsa-share' },
+      { publicKey: 'edroot', keyshare: 'root-eddsa-share' },
+      { publicKey: '02eth', keyshare: 'eth-share' },
+      { publicKey: '02terra', keyshare: 'terra-share' },
+    ])
   })
 })

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,8 @@ module.exports = {
     '^expo/virtual/env$': '<rootDir>/__mocks__/expo-virtual-env.js',
     '^expo-secure-store$':
       '<rootDir>/__tests__/__mocks__/expo-secure-store.ts',
+    '^expo-file-system/legacy$':
+      '<rootDir>/__tests__/__mocks__/expo-file-system-legacy.ts',
     '^.*/modules/legacy-keystore-migration/src$':
       '<rootDir>/__tests__/__mocks__/legacy-keystore.ts',
     '^expo-crypto$': '<rootDir>/__tests__/__mocks__/expo-crypto.ts',
@@ -16,6 +18,14 @@ module.exports = {
   testMatch: [
     '**/__tests__/**/*.test.{js,ts,tsx}',
     '**/__test__/**/*.test.{js,ts,tsx}',
+  ],
+  testPathIgnorePatterns: [
+    '<rootDir>/.claude/worktrees/',
+    '<rootDir>/.worktrees/',
+  ],
+  modulePathIgnorePatterns: [
+    '<rootDir>/.claude/worktrees/',
+    '<rootDir>/.worktrees/',
   ],
   transformIgnorePatterns: [
     'node_modules/(?!(@noble|@scure|react-native|react-native-url-polyfill)/)',

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@terra-money/log-finder-ruleset": "^3.0.3",
         "@terra-money/terra.js": "^3.1.3",
         "@terra.kitchen/utils": "^1.0.7",
-        "@vultisig/mpc-native": "^0.1.3",
+        "@vultisig/mpc-native": "^0.1.4",
         "@vultisig/walletcore-native": "^0.1.2",
         "bech32": "^2.0.0",
         "bignumber.js": "^9.0.1",
@@ -4762,13 +4762,13 @@
       "license": "ISC"
     },
     "node_modules/@vultisig/mpc-native": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@vultisig/mpc-native/-/mpc-native-0.1.3.tgz",
-      "integrity": "sha512-J8kJJjo/SVybdg/F2+9bOa5dXqHVcRV8CKkTZDRuIdRuKAmZgdJU9jVOKNveBWyzqmQnIZE0ODinkfTOU7L0nQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@vultisig/mpc-native/-/mpc-native-0.1.4.tgz",
+      "integrity": "sha512-XDqcuUkIdo9ZHzXySeK61mxLIduMncg4O9+99MyODPntqVcaFfp6YiRUSWRsU4YrbD1ZPV9s4fQOG27imd6/Vw==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-plugins": "^9.0.0",
-        "@vultisig/mpc-types": "^0.1.2"
+        "@vultisig/mpc-types": "^0.2.0"
       },
       "peerDependencies": {
         "expo": "^55.0.0"
@@ -4914,10 +4914,18 @@
       }
     },
     "node_modules/@vultisig/mpc-types": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@vultisig/mpc-types/-/mpc-types-0.1.2.tgz",
-      "integrity": "sha512-WA20Tk2D1hevaLfJAU/wVGAY8EUabPPc/6Z5+Ol9XkyEH4LFSpBrK3bHQh09vm/VmlV+Ldt/K2UFF52Vsw8XCw==",
-      "license": "MIT"
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@vultisig/mpc-types/-/mpc-types-0.2.3.tgz",
+      "integrity": "sha512-4HJhe4JNceVX39d6QUnMp8k0B6676kFA0EJEaTepP7psyUck8VgZV4aMxTdlG2ixcC5S6XSsqkbTtmGvF8ajIA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@vultisig/mpc-wasm": ">=0.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vultisig/mpc-wasm": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vultisig/walletcore-native": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@terra-money/log-finder-ruleset": "^3.0.3",
     "@terra-money/terra.js": "^3.1.3",
     "@terra.kitchen/utils": "^1.0.7",
-    "@vultisig/mpc-native": "^0.1.3",
+    "@vultisig/mpc-native": "^0.1.4",
     "@vultisig/walletcore-native": "^0.1.2",
     "bech32": "^2.0.0",
     "bignumber.js": "^9.0.1",

--- a/src/components/AddWalletSheet.tsx
+++ b/src/components/AddWalletSheet.tsx
@@ -74,12 +74,33 @@ function VaultShareIcon(): React.ReactElement {
   )
 }
 
+function KeyIcon(): React.ReactElement {
+  return (
+    <Svg width={20} height={20} viewBox="0 0 20 20" fill="none">
+      <Circle
+        cx={7}
+        cy={10}
+        r={3}
+        stroke={ICON_BLUE}
+        strokeWidth={1.5}
+      />
+      <Path
+        d="M10 10h7M14 10v3M17 10v2"
+        stroke={ICON_BLUE}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+      />
+    </Svg>
+  )
+}
+
 type Props = {
   visible: boolean
   onDismiss: () => void
   onCreate: () => void
   onRecover: () => void
   onImport: () => void
+  onImportPrivateKey: () => void
   // When false, the "Create new wallet" card is hidden. Used by the
   // import-wallet entry on MigrationHome where the user already declared
   // they have an existing wallet — Create would just be a misroute.
@@ -92,6 +113,7 @@ export default function AddWalletSheet({
   onCreate,
   onRecover,
   onImport,
+  onImportPrivateKey,
   showCreate = true,
 }: Props): React.ReactElement {
   const insets = useSafeAreaInsets()
@@ -220,6 +242,31 @@ export default function AddWalletSheet({
             >
               Enter your seed phrase to recover or convert a legacy
               wallet into a vault.
+            </Text>
+          </Pressable>
+
+          {/* Import private key card */}
+          <Pressable
+            testID="add-wallet-import-private-key"
+            accessibilityRole="button"
+            accessibilityLabel="Import private key"
+            style={styles.card}
+            onPress={dismissAnd(onImportPrivateKey)}
+          >
+            <View style={styles.cardTitleRow}>
+              <KeyIcon />
+              <Text
+                fontType="brockmann-medium"
+                style={styles.cardTitle}
+              >
+                Import private key
+              </Text>
+            </View>
+            <Text
+              fontType="brockmann-medium"
+              style={styles.cardSubtitle}
+            >
+              Convert a Terra private key into a Terra-only vault.
             </Text>
           </Pressable>
 

--- a/src/navigation/MigrationNavigator.tsx
+++ b/src/navigation/MigrationNavigator.tsx
@@ -14,6 +14,7 @@ import BackupVault from '../screens/migration/BackupScreen'
 import ImportVault from '../screens/migration/ImportVault'
 import MigrationSuccess from '../screens/migration/MigrationSuccess'
 import RecoverSeed from '../screens/migration/RecoverSeed'
+import ImportPrivateKey from '../screens/migration/ImportPrivateKey'
 
 // Lazy-load KeygenProgress — it statically imports rive-react-native which
 // initialises its native runtime on import, keeping the iOS main run loop busy
@@ -43,7 +44,11 @@ import type {
   KeyImportResult,
 } from 'services/dklsKeyImport'
 
-export type MigrationMode = 'migrate' | 'create' | 'recover-seed'
+export type MigrationMode =
+  | 'migrate'
+  | 'create'
+  | 'recover-seed'
+  | 'import-private-key'
 
 import { DevFlags } from '../config/env'
 
@@ -61,17 +66,22 @@ export type MigrationStackParams = {
   VaultSetup: undefined
   WalletsFound: undefined
   VaultName: { mode?: MigrationMode } | undefined
+  ImportPrivateKey: {
+    walletName: string
+  }
   VaultEmail: {
     walletName: string
     wallets?: MigrationWallet[]
     mode: MigrationMode
     email?: string
+    privateKeyHex?: string
   }
   VaultPassword: {
     walletName: string
     wallets?: MigrationWallet[]
     mode: MigrationMode
     email: string
+    privateKeyHex?: string
   }
   KeygenProgress: {
     walletName: string
@@ -81,6 +91,7 @@ export type MigrationStackParams = {
     mode: MigrationMode
     email: string
     password: string
+    privateKeyHex?: string
   }
   VerifyEmail: {
     walletName: string
@@ -121,6 +132,7 @@ type MigrationEntry =
   | 'create-vault'
   | 'recover-seed-input'
   | 'import-vault'
+  | 'import-private-key'
 
 export default function MigrationNavigator({
   initialEntry = 'default',
@@ -132,12 +144,16 @@ export default function MigrationNavigator({
       ? 'VaultName'
       : initialEntry === 'import-vault'
       ? 'ImportVault'
+      : initialEntry === 'import-private-key'
+      ? 'VaultName'
       : initialEntry === 'recover-seed-input'
       ? 'RecoverSeed'
       : 'RiveIntro'
   const vaultNameInitialParams =
     initialEntry === 'create-vault'
       ? { mode: 'create' as const }
+      : initialEntry === 'import-private-key'
+      ? { mode: 'import-private-key' as const }
       : undefined
 
   return (
@@ -164,6 +180,10 @@ export default function MigrationNavigator({
         initialParams={vaultNameInitialParams}
       />
       <Stack.Screen name="VaultEmail" component={VaultEmail} />
+      <Stack.Screen
+        name="ImportPrivateKey"
+        component={ImportPrivateKey}
+      />
       <Stack.Screen name="VaultPassword" component={VaultPassword} />
       <Stack.Screen
         name="KeygenProgress"

--- a/src/navigation/MigrationNavigator.tsx
+++ b/src/navigation/MigrationNavigator.tsx
@@ -37,7 +37,11 @@ import type {
   MigrationWallet,
   MigrationResult,
 } from 'services/migrateToVault'
-import type { KeyImportResult } from 'services/dklsKeyImport'
+import type {
+  CreatedFastVaultResult,
+  ImportedSeedFastVaultResult,
+  KeyImportResult,
+} from 'services/dklsKeyImport'
 
 export type MigrationMode = 'migrate' | 'create' | 'recover-seed'
 
@@ -85,7 +89,10 @@ export type MigrationStackParams = {
     results?: MigrationResult[]
     mode: MigrationMode
     email: string
-    keyImportResult: KeyImportResult
+    keyImportResult:
+      | KeyImportResult
+      | CreatedFastVaultResult
+      | ImportedSeedFastVaultResult
   }
   BackupVault: {
     walletName: string

--- a/src/navigation/hooks.ts
+++ b/src/navigation/hooks.ts
@@ -13,6 +13,7 @@ export interface WalletNav {
    */
   startSeedRecoveryInput: () => void
   startImportVault: () => void
+  startImportPrivateKey: () => void
   wallets: LocalWallet[]
   refreshWallets: () => Promise<void>
 }
@@ -25,6 +26,7 @@ export const WalletNavContext = createContext<WalletNav>({
   startCreateVault: (): void => {},
   startSeedRecoveryInput: (): void => {},
   startImportVault: (): void => {},
+  startImportPrivateKey: (): void => {},
   wallets: [],
   refreshWallets: async (): Promise<void> => {},
 })

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -30,6 +30,7 @@ export type MigrationEntry =
   | 'create-vault'
   | 'recover-seed-input'
   | 'import-vault'
+  | 'import-private-key'
 
 export default function AppNavigator(): React.ReactElement | null {
   const [wallets, setWallets] = useState<LocalWallet[] | null>(null)
@@ -127,6 +128,12 @@ export default function AppNavigator(): React.ReactElement | null {
     setRootRoute('Migration')
   }, [])
 
+  const startImportPrivateKey = useCallback(() => {
+    preMigrationRootRef.current = rootRouteRef.current
+    setMigrationEntry('import-private-key')
+    setRootRoute('Migration')
+  }, [])
+
   const goToAuth = useCallback(() => {
     setMigrationEntry('default')
     setRootRoute('Auth')
@@ -173,6 +180,7 @@ export default function AppNavigator(): React.ReactElement | null {
       startCreateVault,
       startSeedRecoveryInput,
       startImportVault,
+      startImportPrivateKey,
       wallets,
       refreshWallets,
     }),
@@ -184,6 +192,7 @@ export default function AppNavigator(): React.ReactElement | null {
       startCreateVault,
       startSeedRecoveryInput,
       startImportVault,
+      startImportPrivateKey,
       wallets,
       refreshWallets,
     ]

--- a/src/screens/WalletList.tsx
+++ b/src/screens/WalletList.tsx
@@ -42,6 +42,7 @@ export default function WalletList(): React.ReactElement {
     startCreateVault,
     startSeedRecoveryInput,
     startImportVault,
+    startImportPrivateKey,
   } = useWalletNav()
 
   // Refresh the list of wallets on focus so returning from the
@@ -242,6 +243,14 @@ export default function WalletList(): React.ReactElement {
           inMigrationNav
             ? (): void => migrationNav.navigate('ImportVault')
             : startImportVault
+        }
+        onImportPrivateKey={
+          inMigrationNav
+            ? (): void =>
+                migrationNav.navigate('VaultName', {
+                  mode: 'import-private-key',
+                })
+            : startImportPrivateKey
         }
       />
     </View>

--- a/src/screens/auth/AuthMenu.tsx
+++ b/src/screens/auth/AuthMenu.tsx
@@ -22,6 +22,7 @@ const AuthMenu = ({
     goToMigration,
     startCreateVault,
     startImportVault,
+    startImportPrivateKey,
     startSeedRecoveryInput,
   } = useWalletNav()
   const insets = useSafeAreaInsets()
@@ -82,6 +83,16 @@ const AuthMenu = ({
           >
             <Text style={styles.secondaryButtonText}>
               Import Fast Vault
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            testID="auth-import-private-key"
+            style={styles.secondaryButton}
+            onPress={startImportPrivateKey}
+          >
+            <Text style={styles.secondaryButtonText}>
+              Import Private Key
             </Text>
           </TouchableOpacity>
 

--- a/src/screens/migration/BackupScreen.tsx
+++ b/src/screens/migration/BackupScreen.tsx
@@ -29,7 +29,6 @@ import { useNavigation, useRoute } from '@react-navigation/native'
 import type { StackNavigationProp } from '@react-navigation/stack'
 import type { RouteProp } from '@react-navigation/native'
 import Svg, { Path } from 'react-native-svg'
-import RiveComponent, { Fit as RiveFitEnum } from 'rive-react-native'
 
 import Text from 'components/Text'
 import Button from 'components/Button'
@@ -49,6 +48,23 @@ type Route = RouteProp<MigrationStackParams, 'BackupVault'>
 type BackupStep = 'options' | 'password' | 'done'
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window')
+
+let RiveComponent: React.ComponentType<
+  Record<string, unknown>
+> | null = null
+let RiveFitEnum: { FitWidth?: unknown } | null = null
+try {
+  const Rive = require('rive-react-native')
+  RiveComponent = Rive.default
+  RiveFitEnum = Rive.Fit
+} catch {
+  /* rive not available */
+}
+
+const riveSource =
+  RiveComponent && !__DEV__
+    ? require('../../../assets/animations/backupvault_splash.riv')
+    : null
 
 function InfoBox({
   icon,
@@ -333,12 +349,49 @@ export default function BackupVault(): React.ReactElement {
         showsVerticalScrollIndicator={false}
       >
         <View style={styles.rivePlaceholder}>
-          <RiveComponent
-            source={require('../../../assets/animations/backupvault_splash.riv')}
-            autoplay
-            fit={RiveFitEnum.FitWidth}
-            style={{ width: SCREEN_WIDTH, height: 220 }}
-          />
+          {RiveComponent && riveSource ? (
+            <RiveComponent
+              source={riveSource}
+              autoplay
+              fit={RiveFitEnum?.FitWidth}
+              style={{ width: SCREEN_WIDTH, height: 220 }}
+              onError={() => {}}
+            />
+          ) : (
+            <View style={styles.backupFallback}>
+              <Svg
+                width={72}
+                height={72}
+                viewBox="0 0 72 72"
+                fill="none"
+              >
+                <Path
+                  d="M18 28h36a4 4 0 014 4v22a4 4 0 01-4 4H18a4 4 0 01-4-4V32a4 4 0 014-4z"
+                  stroke={MIGRATION.ctaBlue}
+                  strokeWidth={2.4}
+                />
+                <Path
+                  d="M24 28v-6a12 12 0 0124 0v6"
+                  stroke={MIGRATION.ctaBlue}
+                  strokeWidth={2.4}
+                  strokeLinecap="round"
+                />
+                <Path
+                  d="M36 39v9"
+                  stroke={MIGRATION.textPrimary}
+                  strokeWidth={2.4}
+                  strokeLinecap="round"
+                />
+                <Path
+                  d="M32 43.5l4 4 4-4"
+                  stroke={MIGRATION.textPrimary}
+                  strokeWidth={2.4}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </Svg>
+            </View>
+          )}
         </View>
         <Text fontType="brockmann-medium" style={styles.title}>
           Protect your backup
@@ -446,6 +499,12 @@ const styles = StyleSheet.create({
   rivePlaceholder: {
     alignItems: 'center',
     marginTop: 8,
+  },
+  backupFallback: {
+    width: SCREEN_WIDTH,
+    height: 220,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   title: {
     fontSize: 22,

--- a/src/screens/migration/ImportPrivateKey.tsx
+++ b/src/screens/migration/ImportPrivateKey.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { View, StyleSheet, TextInput } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useNavigation, useRoute } from '@react-navigation/native'
@@ -15,31 +15,35 @@ import StepProgressBar from 'components/migration/StepProgressBar'
 import MigrationToolbar from 'components/migration/MigrationToolbar'
 import { formStyles } from 'components/migration/migrationStyles'
 import { MIGRATION } from 'consts/migration'
-import { isValidEmail } from 'utils/isValidEmail'
 import type { MigrationStackParams } from 'navigation/MigrationNavigator'
+import {
+  validatePrivateKey,
+  type ValidatedPrivateKey,
+} from 'services/privateKeyImport'
 
-type Nav = StackNavigationProp<MigrationStackParams, 'VaultEmail'>
-type Route = RouteProp<MigrationStackParams, 'VaultEmail'>
+type Nav = StackNavigationProp<
+  MigrationStackParams,
+  'ImportPrivateKey'
+>
+type Route = RouteProp<MigrationStackParams, 'ImportPrivateKey'>
 
-export default function VaultEmail(): React.ReactElement {
+export default function ImportPrivateKey(): React.ReactElement {
   const navigation = useNavigation<Nav>()
   const route = useRoute<Route>()
-  const {
-    walletName,
-    mode,
-    wallets,
-    email: prefillEmail,
-    privateKeyHex,
-  } = route.params
-
-  const [email, setEmail] = useState(prefillEmail ?? '')
-
-  const valid = isValidEmail(email)
-  const showError = email.length > 0 && !valid
-
-  const stepBarCurrentStep = mode === 'create' ? 2 : 1
-
+  const { walletName } = route.params
   const insets = useSafeAreaInsets()
+  const [value, setValue] = useState('')
+
+  const validated = useMemo<ValidatedPrivateKey | null>(() => {
+    if (!value.trim()) return null
+    try {
+      return validatePrivateKey(value)
+    } catch {
+      return null
+    }
+  }, [value])
+
+  const showError = value.trim().length > 0 && !validated
 
   return (
     <View style={formStyles.container}>
@@ -48,7 +52,7 @@ export default function VaultEmail(): React.ReactElement {
           <MigrationToolbar onBack={() => navigation.goBack()} />
         </View>
 
-        <StepProgressBar currentStep={stepBarCurrentStep} />
+        <StepProgressBar currentStep={2} />
 
         <Animated.View
           entering={FadeInRight.duration(250)}
@@ -56,32 +60,48 @@ export default function VaultEmail(): React.ReactElement {
           style={formStyles.content}
         >
           <Text style={formStyles.title} fontType="brockmann-medium">
-            Enter your email
+            Import private key
           </Text>
-
           <Text style={formStyles.subtitle} fontType="brockmann">
-            This will only be used once to send your backup file.
-            Vultisig doesn&apos;t store any data.
+            This imports a Terra private key only. Use seed phrase
+            recovery for a multichain wallet.
           </Text>
 
           <TextInput
-            testID="vault-email-input"
+            testID="private-key-input"
             style={[styles.input, showError && styles.inputError]}
-            value={email}
-            onChangeText={setEmail}
-            placeholder="you@example.com"
-            placeholderTextColor={MIGRATION.textTertiary}
-            keyboardType="email-address"
+            value={value}
+            onChangeText={setValue}
+            placeholder="Paste private key"
+            placeholderTextColor={MIGRATION.textInputPlaceholder}
             autoCapitalize="none"
             autoCorrect={false}
-            autoComplete="email"
+            secureTextEntry
           />
 
-          {showError && (
+          {showError ? (
             <Text style={styles.errorText} fontType="brockmann">
-              Incorrect e-mail, please check
+              Enter a valid 64-character hex private key.
             </Text>
-          )}
+          ) : null}
+
+          {validated ? (
+            <View style={styles.preview}>
+              <Text
+                fontType="brockmann-medium"
+                style={styles.previewLabel}
+              >
+                Terra address
+              </Text>
+              <Text
+                fontType="brockmann"
+                style={styles.previewAddress}
+                numberOfLines={2}
+              >
+                {validated.terraAddress}
+              </Text>
+            </View>
+          ) : null}
         </Animated.View>
 
         <View
@@ -91,18 +111,17 @@ export default function VaultEmail(): React.ReactElement {
           ]}
         >
           <Button
-            testID="vault-email-next"
-            title="Next"
+            testID="private-key-next"
+            title="Continue"
             theme="ctaBlue"
             titleFontType="brockmann-medium"
-            disabled={!valid}
+            disabled={!validated}
             onPress={() => {
-              navigation.navigate('VaultPassword', {
+              if (!validated) return
+              navigation.navigate('VaultEmail', {
                 walletName,
-                mode,
-                wallets,
-                email,
-                privateKeyHex,
+                mode: 'import-private-key',
+                privateKeyHex: validated.privateKeyHex,
               })
             }}
             containerStyle={formStyles.ctaButton}
@@ -132,5 +151,23 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: MIGRATION.errorRed,
     marginTop: 6,
+  },
+  preview: {
+    marginTop: 18,
+    padding: 16,
+    borderRadius: 12,
+    backgroundColor: MIGRATION.surface1,
+    borderWidth: 1,
+    borderColor: MIGRATION.strokeInput,
+  },
+  previewLabel: {
+    fontSize: 12,
+    color: MIGRATION.textTertiary,
+    marginBottom: 8,
+  },
+  previewAddress: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: MIGRATION.textPrimary,
   },
 })

--- a/src/screens/migration/KeygenProgress.tsx
+++ b/src/screens/migration/KeygenProgress.tsx
@@ -28,14 +28,16 @@ import Text from 'components/Text'
 import Button from 'components/Button'
 import { MIGRATION } from 'consts/migration'
 import {
+  createFastVault,
+  importSeedPhraseToFastVault,
   importKeyToFastVault,
+  CreatedFastVaultResult,
+  ImportedSeedFastVaultResult,
   KeyImportResult,
   KeyImportProgress,
 } from 'services/dklsKeyImport'
 import { getAuthDataValue, AuthDataValueType } from 'utils/authData'
 import { decrypt } from 'utils/crypto'
-import { randomHex } from 'utils/mpcCrypto'
-import { generateAddresses } from 'utils/wallet'
 import RecoverWalletStore from 'stores/RecoverWalletStore'
 import type { MigrationResult } from 'services/migrateToVault'
 import { advanceToNextWallet } from 'utils/migrationNav'
@@ -179,15 +181,16 @@ export default function KeygenProgress(): React.ReactElement {
     abortRef.current = controller
 
     try {
-      let result: KeyImportResult
+      let result:
+        | KeyImportResult
+        | CreatedFastVaultResult
+        | ImportedSeedFastVaultResult
 
       if (mode === 'create') {
-        const privateKeyHex = randomHex(32)
-        result = await importKeyToFastVault({
+        result = await createFastVault({
           name: walletName,
           email,
           password,
-          privateKeyHex,
           onProgress: updateProgress,
           signal: controller.signal,
         })
@@ -195,13 +198,11 @@ export default function KeygenProgress(): React.ReactElement {
         if (recoverSeed.length === 0) {
           throw new Error('No seed phrase available for recovery')
         }
-        const { mk330 } = generateAddresses(recoverSeed.join(' '))
-        const privateKeyHex = mk330.privateKey.toString('hex')
-        result = await importKeyToFastVault({
+        result = await importSeedPhraseToFastVault({
           name: walletName,
           email,
           password,
-          privateKeyHex,
+          mnemonic: recoverSeed.join(' '),
           onProgress: updateProgress,
           signal: controller.signal,
         })

--- a/src/screens/migration/KeygenProgress.tsx
+++ b/src/screens/migration/KeygenProgress.tsx
@@ -62,6 +62,7 @@ export default function KeygenProgress(): React.ReactElement {
     email,
     password,
     mode,
+    privateKeyHex,
   } = route.params
 
   const [progress, setProgress] = useState(0)
@@ -206,6 +207,18 @@ export default function KeygenProgress(): React.ReactElement {
           onProgress: updateProgress,
           signal: controller.signal,
         })
+      } else if (mode === 'import-private-key') {
+        if (!privateKeyHex) {
+          throw new Error('No private key available for import')
+        }
+        result = await importKeyToFastVault({
+          name: walletName,
+          email,
+          password,
+          privateKeyHex,
+          onProgress: updateProgress,
+          signal: controller.signal,
+        })
       } else {
         const authEntry = await getAuthDataValue(walletName)
         if (!authEntry || authEntry.ledger) {
@@ -256,6 +269,7 @@ export default function KeygenProgress(): React.ReactElement {
     walletIndex,
     updateProgress,
     recoverSeed,
+    privateKeyHex,
   ])
 
   useEffect(() => {

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -56,6 +56,9 @@ export default function MigrationHome(): React.ReactElement {
   const startImportVaultFromHere = (): void => {
     navigation.navigate('ImportVault')
   }
+  const startImportPrivateKeyFromHere = (): void => {
+    navigation.navigate('VaultName', { mode: 'import-private-key' })
+  }
   const startCreateVaultFromHere = (): void => {
     navigation.navigate('VaultName', { mode: 'create' })
   }
@@ -251,6 +254,7 @@ export default function MigrationHome(): React.ReactElement {
         onCreate={startCreateVaultFromHere}
         onRecover={startSeedRecoveryFromHere}
         onImport={startImportVaultFromHere}
+        onImportPrivateKey={startImportPrivateKeyFromHere}
         // MigrationHome's "Import wallet" entry is for users who already
         // have a wallet — Create would just be a misroute. The shared sheet
         // still defaults to showing it for the WalletList entry.

--- a/src/screens/migration/VaultName.tsx
+++ b/src/screens/migration/VaultName.tsx
@@ -99,10 +99,17 @@ export default function VaultName(): React.ReactElement {
             disabled={name.trim().length === 0}
             titleFontType="brockmann-medium"
             onPress={() => {
-              navigation.navigate('VaultEmail', {
-                walletName: name.trim(),
-                mode,
-              })
+              const walletName = name.trim()
+              if (mode === 'import-private-key') {
+                navigation.navigate('ImportPrivateKey', {
+                  walletName,
+                })
+              } else {
+                navigation.navigate('VaultEmail', {
+                  walletName,
+                  mode,
+                })
+              }
             }}
             containerStyle={formStyles.ctaButton}
           />

--- a/src/screens/migration/VaultPassword.tsx
+++ b/src/screens/migration/VaultPassword.tsx
@@ -23,7 +23,8 @@ type Route = RouteProp<MigrationStackParams, 'VaultPassword'>
 export default function VaultPassword(): React.ReactElement {
   const navigation = useNavigation<Nav>()
   const route = useRoute<Route>()
-  const { walletName, mode, wallets, email } = route.params
+  const { walletName, mode, wallets, email, privateKeyHex } =
+    route.params
 
   const [password, setPassword] = useState('')
   const [confirm, setConfirm] = useState('')
@@ -132,6 +133,7 @@ export default function VaultPassword(): React.ReactElement {
                 wallets,
                 email,
                 password,
+                privateKeyHex,
               })
             }}
             containerStyle={formStyles.ctaButton}

--- a/src/services/dklsKeyImport.stub.ts
+++ b/src/services/dklsKeyImport.stub.ts
@@ -1,8 +1,61 @@
 import type {
+  CreatedFastVaultResult,
+  ImportedSeedFastVaultResult,
   KeyImportResult,
   KeyImportProgress,
 } from './dklsKeyImport'
 import { derivePublicKeyHex } from './vaultProto'
+import {
+  deriveChainKeyForImport,
+  deriveMasterKeys,
+  SEED_IMPORT_DERIVATION_GROUPS,
+} from './seedPhraseImport'
+
+export async function createFastVault(options: {
+  name: string
+  email: string
+  password: string
+  onProgress?: (p: KeyImportProgress) => void
+  signal?: AbortSignal
+}): Promise<CreatedFastVaultResult> {
+  const { onProgress, signal } = options
+
+  const steps: KeyImportProgress[] = [
+    { step: 'setup', message: 'Generating session...', progress: 10 },
+    { step: 'joining', message: 'Joining relay...', progress: 25 },
+    {
+      step: 'ecdsa',
+      message: 'Running ECDSA MPC protocol...',
+      progress: 50,
+    },
+    {
+      step: 'eddsa',
+      message: 'Running EdDSA MPC protocol...',
+      progress: 75,
+    },
+    { step: 'complete', message: 'Complete!', progress: 100 },
+  ]
+  for (const s of steps) {
+    if (signal?.aborted) throw new Error('Aborted')
+    onProgress?.(s)
+    await Promise.resolve()
+  }
+
+  return {
+    publicKey:
+      '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+    publicKeyEcdsa:
+      '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+    publicKeyEddsa:
+      '3b6a27bcceb6a42d62a3a8d02a6f0d736f85ee7d74c87866438df8b9882c4b20',
+    keyshareEcdsa: 'c3R1Yi1lY2RzYS1rZXlzaGFyZQ==',
+    keyshareEddsa: 'c3R1Yi1lZGRzYS1rZXlzaGFyZQ==',
+    chainCode:
+      '7923408dadd3c7b56eed15567707ae5e5dca089de972e07f3b860450e2a3b70e',
+    localPartyId: 'sdk-stub0',
+    serverPartyId: 'Server-stub',
+  }
+}
 
 export async function importKeyToFastVault(options: {
   name: string
@@ -43,5 +96,68 @@ export async function importKeyToFastVault(options: {
     chainCode: '0'.repeat(64),
     localPartyId: 'sdk-stub0',
     serverPartyId: 'Server-stub',
+  }
+}
+
+export async function importSeedPhraseToFastVault(options: {
+  name: string
+  email: string
+  password: string
+  mnemonic: string
+  onProgress?: (p: KeyImportProgress) => void
+  signal?: AbortSignal
+}): Promise<ImportedSeedFastVaultResult> {
+  const { mnemonic, onProgress, signal } = options
+  const steps: KeyImportProgress[] = [
+    { step: 'setup', message: 'Generating session...', progress: 10 },
+    {
+      step: 'ecdsa',
+      message: 'Importing ECDSA keys...',
+      progress: 45,
+    },
+    {
+      step: 'eddsa',
+      message: 'Importing EdDSA keys...',
+      progress: 80,
+    },
+    { step: 'complete', message: 'Complete!', progress: 100 },
+  ]
+  for (const s of steps) {
+    if (signal?.aborted) throw new Error('Aborted')
+    onProgress?.(s)
+    await Promise.resolve()
+  }
+
+  const master = deriveMasterKeys(mnemonic)
+  const importedChains = await Promise.all(
+    SEED_IMPORT_DERIVATION_GROUPS.map(async (group) => {
+      const chainKey = await deriveChainKeyForImport(
+        mnemonic,
+        group.representativeChain
+      )
+      const publicKey = chainKey.isEddsa
+        ? `ed-${group.representativeChain}`
+        : derivePublicKeyHex(chainKey.privateKey)
+
+      return {
+        chain: group.representativeChain,
+        publicKey,
+        keyshare: `stub-${group.representativeChain}-share`,
+        isEddsa: chainKey.isEddsa,
+      }
+    })
+  )
+
+  return {
+    publicKey: derivePublicKeyHex(master.ecdsaPrivateKey),
+    publicKeyEcdsa: derivePublicKeyHex(master.ecdsaPrivateKey),
+    publicKeyEddsa:
+      '3b6a27bcceb6a42d62a3a8d02a6f0d736f85ee7d74c87866438df8b9882c4b20',
+    keyshareEcdsa: 'c3R1Yi1zZWVkLXJvb3QtZWNkc2E=',
+    keyshareEddsa: 'c3R1Yi1zZWVkLXJvb3QtZWRkc2E=',
+    chainCode: master.ecdsaChainCode,
+    localPartyId: 'sdk-stub0',
+    serverPartyId: 'Server-stub',
+    importedChains,
   }
 }

--- a/src/services/dklsKeyImport.ts
+++ b/src/services/dklsKeyImport.ts
@@ -10,7 +10,11 @@ import {
   signalComplete,
   waitForComplete,
 } from './relay'
-import { setupBatchImport } from './fastVaultServer'
+import {
+  setupBatchImport,
+  setupBatchKeygen,
+  setupKeyImport,
+} from './fastVaultServer'
 import {
   encryptAesGcm,
   decryptAesGcm,
@@ -22,12 +26,21 @@ import {
 } from '../utils/mpcCrypto'
 import { STUB_VULTISERVER } from '../config/env'
 import * as stubDkls from './dklsKeyImport.stub'
+import {
+  deriveChainPublicKeyForImport,
+  deriveChainKey,
+  deriveChainKeyForImport,
+  deriveMasterKeys,
+  SEED_IMPORT_DERIVATION_GROUPS,
+  SeedImportChain,
+} from './seedPhraseImport'
 
 export type KeyImportStep =
   | 'setup'
   | 'joining'
   | 'waiting'
   | 'ecdsa'
+  | 'eddsa'
   | 'finalizing'
   | 'complete'
 
@@ -45,6 +58,36 @@ export type KeyImportResult = {
   serverPartyId: string
 }
 
+export type CreatedFastVaultResult = {
+  publicKey: string
+  publicKeyEcdsa: string
+  publicKeyEddsa: string
+  keyshareEcdsa: string
+  keyshareEddsa: string
+  chainCode: string
+  localPartyId: string
+  serverPartyId: string
+}
+
+export type ImportedSeedChainResult = {
+  chain: SeedImportChain
+  publicKey: string
+  keyshare: string
+  isEddsa: boolean
+}
+
+export type ImportedSeedFastVaultResult = CreatedFastVaultResult & {
+  importedChains: ImportedSeedChainResult[]
+}
+
+type NativeKeygenResult = {
+  publicKey: string
+  keyshare: string
+  chainCode: string
+}
+
+type MpcKeyType = 'ecdsa' | 'eddsa'
+
 /**
  * Run the DKLS MPC message exchange loop with a messageId for relay routing.
  * The batch endpoint uses "p-ecdsa" as the messageId for the ECDSA protocol.
@@ -54,7 +97,8 @@ async function runMpcProtocol(
   sessionId: string,
   localPartyId: string,
   cipherKey: Uint8Array,
-  messageId: string,
+  keyType: MpcKeyType,
+  messageId: string | undefined,
   onProgress?: (progressPercent: number) => void,
   signal?: AbortSignal
 ): Promise<void> {
@@ -70,7 +114,11 @@ async function runMpcProtocol(
       if (signal?.aborted) throw new Error('Aborted')
       try {
         const outMsg =
-          ExpoDkls.keygenSessionOutputMessage(sessionHandle)
+          keyType === 'ecdsa'
+            ? ExpoDkls.keygenSessionOutputMessage(sessionHandle)
+            : ExpoDkls.schnorrKeygenSessionOutputMessage(
+                sessionHandle
+              )
         if (!outMsg) {
           await sleep(100)
           continue
@@ -81,11 +129,18 @@ async function runMpcProtocol(
 
         let idx = 0
         while (true) {
-          const receiver = ExpoDkls.keygenSessionMessageReceiver(
-            sessionHandle,
-            outMsg,
-            idx
-          )
+          const receiver =
+            keyType === 'ecdsa'
+              ? ExpoDkls.keygenSessionMessageReceiver(
+                  sessionHandle,
+                  outMsg,
+                  idx
+                )
+              : ExpoDkls.schnorrKeygenSessionMessageReceiver(
+                  sessionHandle,
+                  outMsg,
+                  idx
+                )
           if (!receiver) break
           await sendRelayMessage(
             sessionId,
@@ -130,10 +185,16 @@ async function runMpcProtocol(
           if (processedMessages.has(cacheKey)) continue
 
           const decrypted = decryptAesGcm(msg.body, cipherKey)
-          const finished = ExpoDkls.keygenSessionInputMessage(
-            sessionHandle,
-            decrypted
-          )
+          const finished =
+            keyType === 'ecdsa'
+              ? ExpoDkls.keygenSessionInputMessage(
+                  sessionHandle,
+                  decrypted
+                )
+              : ExpoDkls.schnorrKeygenSessionInputMessage(
+                  sessionHandle,
+                  decrypted
+                )
           processedMessages.add(cacheKey)
           await deleteRelayMessage(
             sessionId,
@@ -171,6 +232,522 @@ async function runMpcProtocol(
   await Promise.all([processOutbound(), processInbound()])
   if (!isComplete) throw new Error('MPC protocol did not complete')
   onProgress?.(1.0)
+}
+
+function serverPartyIdFromSession(sessionId: string): string {
+  let serverHash = 0
+  for (let i = 0; i < sessionId.length; i++) {
+    serverHash =
+      (serverHash << 5) - serverHash + sessionId.charCodeAt(i)
+    serverHash = serverHash & serverHash
+  }
+  return `Server-${Math.abs(serverHash).toString().slice(-5)}`
+}
+
+async function finishNativeKeygen(
+  keyType: MpcKeyType,
+  sessionHandle: number
+): Promise<NativeKeygenResult> {
+  return keyType === 'ecdsa'
+    ? ExpoDkls.finishKeygen(sessionHandle)
+    : ExpoDkls.finishSchnorrKeygen(sessionHandle)
+}
+
+function freeNativeKeygen(
+  keyType: MpcKeyType,
+  sessionHandle: number
+): void {
+  if (keyType === 'ecdsa') {
+    ExpoDkls.freeKeygenSession(sessionHandle)
+  } else {
+    ExpoDkls.freeSchnorrKeygenSession(sessionHandle)
+  }
+}
+
+async function prepareKeyImportSession(options: {
+  privateKeyHex: string
+  chainCodeHex: string
+  keyType: MpcKeyType
+  parties: string[]
+  sessionId: string
+  cipherKey: Uint8Array
+  setupMessageId?: string
+}): Promise<number> {
+  const {
+    privateKeyHex,
+    chainCodeHex,
+    keyType,
+    parties,
+    sessionId,
+    cipherKey,
+    setupMessageId,
+  } = options
+  const importResult =
+    keyType === 'ecdsa'
+      ? (ExpoDkls.createDklsKeyImportInitiator(
+          privateKeyHex,
+          chainCodeHex,
+          2,
+          parties
+        ) as { setupMessage: string; sessionHandle: number })
+      : (ExpoDkls.createSchnorrKeyImportInitiator(
+          privateKeyHex,
+          chainCodeHex,
+          2,
+          parties
+        ) as { setupMessage: string; sessionHandle: number })
+
+  await uploadSetupMessage(
+    sessionId,
+    encryptAesGcm(importResult.setupMessage, cipherKey),
+    setupMessageId
+  )
+
+  return importResult.sessionHandle
+}
+
+async function runPreparedImport(options: {
+  sessionHandle: number
+  sessionId: string
+  localPartyId: string
+  cipherKey: Uint8Array
+  keyType: MpcKeyType
+  messageId?: string
+  signal?: AbortSignal
+  onProgress?: (progressPercent: number) => void
+}): Promise<NativeKeygenResult> {
+  const {
+    sessionHandle,
+    sessionId,
+    localPartyId,
+    cipherKey,
+    keyType,
+    messageId,
+    signal,
+    onProgress,
+  } = options
+
+  try {
+    await runMpcProtocol(
+      sessionHandle,
+      sessionId,
+      localPartyId,
+      cipherKey,
+      keyType,
+      messageId,
+      onProgress,
+      signal
+    )
+    return finishNativeKeygen(keyType, sessionHandle)
+  } finally {
+    try {
+      freeNativeKeygen(keyType, sessionHandle)
+    } catch {}
+  }
+}
+
+/**
+ * Create a real Vultisig-style DKLS fast vault.
+ *
+ * Created vaults use root ECDSA + root EdDSA + a real chain code. They do not
+ * store per-chain child keys; other Vultisig wallets derive those addresses
+ * from the root keys exactly like any vault created in Vultisig iOS/Android.
+ */
+export async function createFastVault(options: {
+  name: string
+  email: string
+  password: string
+  onProgress?: (p: KeyImportProgress) => void
+  signal?: AbortSignal
+}): Promise<CreatedFastVaultResult> {
+  const { name, email, password, onProgress, signal } = options
+
+  if (STUB_VULTISERVER) return stubDkls.createFastVault(options)
+
+  const report = (p: KeyImportProgress): void => {
+    if (__DEV__) {
+      // eslint-disable-next-line no-console
+      console.log(`[Keygen] ${p.step}: ${p.message} (${p.progress}%)`)
+    }
+    onProgress?.(p)
+  }
+
+  report({
+    step: 'setup',
+    message: 'Generating session...',
+    progress: 5,
+  })
+
+  const sessionId = randomUUID()
+  const hexEncryptionKey = randomHex(32)
+  const hexChainCode = randomHex(32)
+  const localPartyId = `sdk-${randomHex(4)}`
+  let serverPartyId = serverPartyIdFromSession(sessionId)
+
+  report({
+    step: 'setup',
+    message: 'Setting up vault...',
+    progress: 12,
+  })
+
+  await Promise.all([
+    setupBatchKeygen({
+      name,
+      session_id: sessionId,
+      hex_encryption_key: hexEncryptionKey,
+      hex_chain_code: hexChainCode,
+      local_party_id: serverPartyId,
+      encryption_password: password,
+      email,
+      lib_type: 1,
+      protocols: ['ecdsa', 'eddsa'],
+    }),
+    joinRelaySession(sessionId, localPartyId),
+  ])
+
+  report({
+    step: 'waiting',
+    message: 'Waiting for server...',
+    progress: 20,
+  })
+
+  const parties = await waitForParties(sessionId, 2, 120_000, signal)
+  const actualServerPartyId = parties.find((p) => p !== localPartyId)
+  if (!actualServerPartyId)
+    throw new Error('Could not identify server party from relay')
+  serverPartyId = actualServerPartyId
+
+  await startRelaySession(sessionId, parties)
+
+  const cipherKey = deriveCipherKey(hexEncryptionKey)
+  const setupMessage = ExpoDkls.dklsKeygenSetup(2, null, parties)
+  await uploadSetupMessage(
+    sessionId,
+    encryptAesGcm(setupMessage, cipherKey)
+  )
+
+  report({
+    step: 'ecdsa',
+    message: 'Running MPC protocols...',
+    progress: 35,
+  })
+
+  const ecdsaHandle = await ExpoDkls.createKeygenSession(
+    setupMessage,
+    localPartyId
+  )
+  const eddsaHandle = await ExpoDkls.createSchnorrKeygenSession(
+    setupMessage,
+    localPartyId
+  )
+
+  try {
+    await Promise.all([
+      runMpcProtocol(
+        ecdsaHandle,
+        sessionId,
+        localPartyId,
+        cipherKey,
+        'ecdsa',
+        'p-ecdsa',
+        (mpcProgress) => {
+          report({
+            step: 'ecdsa',
+            message: 'Running ECDSA MPC protocol...',
+            progress: Math.round(35 + mpcProgress * 30),
+          })
+        },
+        signal
+      ),
+      runMpcProtocol(
+        eddsaHandle,
+        sessionId,
+        localPartyId,
+        cipherKey,
+        'eddsa',
+        'p-eddsa',
+        (mpcProgress) => {
+          report({
+            step: 'eddsa',
+            message: 'Running EdDSA MPC protocol...',
+            progress: Math.round(35 + mpcProgress * 30),
+          })
+        },
+        signal
+      ),
+    ])
+
+    report({
+      step: 'finalizing',
+      message: 'Extracting keyshares...',
+      progress: 82,
+    })
+
+    const [ecdsaResult, eddsaResult] = await Promise.all([
+      finishNativeKeygen('ecdsa', ecdsaHandle),
+      finishNativeKeygen('eddsa', eddsaHandle),
+    ])
+
+    await signalComplete(sessionId, localPartyId)
+    await waitForComplete(sessionId, parties, 60, 1000, signal)
+
+    report({ step: 'complete', message: 'Complete!', progress: 100 })
+
+    return {
+      publicKey: ecdsaResult.publicKey,
+      publicKeyEcdsa: ecdsaResult.publicKey,
+      publicKeyEddsa: eddsaResult.publicKey,
+      keyshareEcdsa: ecdsaResult.keyshare,
+      keyshareEddsa: eddsaResult.keyshare,
+      chainCode: ecdsaResult.chainCode || hexChainCode,
+      localPartyId,
+      serverPartyId,
+    }
+  } finally {
+    try {
+      freeNativeKeygen('ecdsa', ecdsaHandle)
+    } catch {}
+    try {
+      freeNativeKeygen('eddsa', eddsaHandle)
+    } catch {}
+  }
+}
+
+/**
+ * Import a BIP39 seed phrase using Vultisig's KeyImport shape.
+ *
+ * The root keys identify the vault. Chain-specific keys are imported for every
+ * representative derivation path Station currently needs to be portable across
+ * Vultisig wallets, including Terra's hardened 330 path.
+ */
+export async function importSeedPhraseToFastVault(options: {
+  name: string
+  email: string
+  password: string
+  mnemonic: string
+  onProgress?: (p: KeyImportProgress) => void
+  signal?: AbortSignal
+}): Promise<ImportedSeedFastVaultResult> {
+  const { name, email, password, mnemonic, onProgress, signal } =
+    options
+
+  if (STUB_VULTISERVER)
+    return stubDkls.importSeedPhraseToFastVault(options)
+
+  const masterKeys = deriveMasterKeys(mnemonic)
+  const report = (p: KeyImportProgress): void => {
+    if (__DEV__) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[SeedImport] ${p.step}: ${p.message} (${p.progress}%)`
+      )
+    }
+    onProgress?.(p)
+  }
+
+  report({
+    step: 'setup',
+    message: 'Generating session...',
+    progress: 5,
+  })
+
+  const sessionId = randomUUID()
+  const hexEncryptionKey = randomHex(32)
+  const importChainCode = masterKeys.ecdsaChainCode
+  const localPartyId = `sdk-${randomHex(4)}`
+  let serverPartyId = serverPartyIdFromSession(sessionId)
+
+  await Promise.all([
+    setupKeyImport({
+      name,
+      session_id: sessionId,
+      hex_encryption_key: hexEncryptionKey,
+      hex_chain_code: importChainCode,
+      local_party_id: serverPartyId,
+      encryption_password: password,
+      email,
+      lib_type: 2,
+      chains: ['Terra'],
+    }),
+    joinRelaySession(sessionId, localPartyId),
+  ])
+
+  report({
+    step: 'waiting',
+    message: 'Waiting for server...',
+    progress: 15,
+  })
+
+  const parties = await waitForParties(sessionId, 2, 120_000, signal)
+  const actualServerPartyId = parties.find((p) => p !== localPartyId)
+  if (!actualServerPartyId)
+    throw new Error('Could not identify server party from relay')
+  serverPartyId = actualServerPartyId
+
+  await startRelaySession(sessionId, parties)
+
+  const cipherKey = deriveCipherKey(hexEncryptionKey)
+
+  report({
+    step: 'setup',
+    message: 'Preparing key imports...',
+    progress: 20,
+  })
+
+  const rootEcdsaHandle = await prepareKeyImportSession({
+    privateKeyHex: masterKeys.ecdsaPrivateKey,
+    chainCodeHex: importChainCode,
+    keyType: 'ecdsa',
+    parties,
+    sessionId,
+    cipherKey,
+  })
+  const rootEddsaHandle = await prepareKeyImportSession({
+    privateKeyHex: masterKeys.eddsaPrivateKey,
+    chainCodeHex: importChainCode,
+    keyType: 'eddsa',
+    parties,
+    sessionId,
+    cipherKey,
+    setupMessageId: 'eddsa_key_import',
+  })
+  const terraKey = await deriveChainKeyForImport(mnemonic, 'Terra')
+  const terraChainCode = deriveChainKey(mnemonic, 'Terra').chainCode
+  const terraHandle = await prepareKeyImportSession({
+    privateKeyHex: terraKey.privateKey,
+    chainCodeHex: terraChainCode,
+    keyType: 'ecdsa',
+    parties,
+    sessionId,
+    cipherKey,
+    setupMessageId: 'Terra',
+  })
+
+  const runRootEcdsa = async (): Promise<NativeKeygenResult> => {
+    report({
+      step: 'ecdsa',
+      message: 'Importing ECDSA root key...',
+      progress: 30,
+    })
+    return runPreparedImport({
+      sessionHandle: rootEcdsaHandle,
+      sessionId,
+      localPartyId,
+      cipherKey,
+      keyType: 'ecdsa',
+      signal,
+      onProgress: (mpcProgress) => {
+        report({
+          step: 'ecdsa',
+          message: 'Importing ECDSA root key...',
+          progress: Math.round(30 + mpcProgress * 20),
+        })
+      },
+    })
+  }
+
+  const runRootEddsa = async (): Promise<NativeKeygenResult> => {
+    report({
+      step: 'eddsa',
+      message: 'Importing EdDSA root key...',
+      progress: 30,
+    })
+    try {
+      return await runPreparedImport({
+        sessionHandle: rootEddsaHandle,
+        sessionId,
+        localPartyId,
+        cipherKey,
+        keyType: 'eddsa',
+        signal,
+        onProgress: (mpcProgress) => {
+          report({
+            step: 'eddsa',
+            message: 'Importing EdDSA root key...',
+            progress: Math.round(30 + mpcProgress * 20),
+          })
+        },
+      })
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : String(error)
+      throw new Error(`root eddsa import failed: ${message}`)
+    }
+  }
+
+  const runRootEcdsaWrapped =
+    async (): Promise<NativeKeygenResult> => {
+      try {
+        return await runRootEcdsa()
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : String(error)
+        throw new Error(`root ecdsa import failed: ${message}`)
+      }
+    }
+
+  const rootEcdsa = await runRootEcdsaWrapped()
+  const rootEddsa = await runRootEddsa()
+  const terraResult = await runPreparedImport({
+    sessionHandle: terraHandle,
+    sessionId,
+    localPartyId,
+    cipherKey,
+    keyType: 'ecdsa',
+    signal,
+    onProgress: (mpcProgress) => {
+      report({
+        step: 'ecdsa',
+        message: 'Importing Terra key...',
+        progress: Math.round(55 + mpcProgress * 30),
+      })
+    },
+  })
+
+  const chainPublicKeys = (
+    await Promise.all(
+      SEED_IMPORT_DERIVATION_GROUPS.map(
+        async (group): Promise<ImportedSeedChainResult[]> => {
+          const publicKey = await deriveChainPublicKeyForImport(
+            mnemonic,
+            group.representativeChain
+          )
+          return group.chains.map((chain) => ({
+            chain,
+            publicKey,
+            keyshare:
+              chain === 'Terra' || chain === 'TerraClassic'
+                ? terraResult.keyshare
+                : '',
+            isEddsa: group.isEddsa,
+          }))
+        }
+      )
+    )
+  ).flat()
+
+  report({
+    step: 'finalizing',
+    message: 'Finalizing vault...',
+    progress: 92,
+  })
+
+  await signalComplete(sessionId, localPartyId)
+  await waitForComplete(sessionId, parties, 60, 1000, signal)
+
+  report({ step: 'complete', message: 'Complete!', progress: 100 })
+
+  return {
+    publicKey: rootEcdsa.publicKey,
+    publicKeyEcdsa: rootEcdsa.publicKey,
+    publicKeyEddsa: rootEddsa.publicKey,
+    keyshareEcdsa: rootEcdsa.keyshare,
+    keyshareEddsa: rootEddsa.keyshare,
+    chainCode: rootEcdsa.chainCode || importChainCode,
+    localPartyId,
+    serverPartyId,
+    importedChains: chainPublicKeys,
+  }
 }
 
 /**
@@ -235,10 +812,10 @@ export async function importKeyToFastVault(options: {
       name,
       session_id: sessionId,
       hex_encryption_key: hexEncryptionKey,
-      hex_chain_code: hexChainCode,
       local_party_id: serverPartyId,
       encryption_password: password,
       email,
+      lib_type: 2,
       protocols: ['ecdsa'],
     }),
     joinRelaySession(sessionId, localPartyId),
@@ -303,6 +880,7 @@ export async function importKeyToFastVault(options: {
       sessionId,
       localPartyId,
       cipherKey,
+      'ecdsa',
       'p-ecdsa',
       (mpcProgress) => {
         const stepProgress = 48 + mpcProgress * 38

--- a/src/services/exportVaultShare.ts
+++ b/src/services/exportVaultShare.ts
@@ -36,9 +36,14 @@ export async function exportVaultShare(
 
   const stored = await getStoredVault(walletName)
   if (stored) {
-    // Check if the stored vault is a DKLS fast vault — read directly
+    // Stored vaults are already safe to export directly. That includes
+    // created DKLS vaults and migrated Terra-only KEYIMPORT vaults whose
+    // keyshare is an MPC share, not the old raw Station private key.
     const decoded = fromBinary(VaultSchema, base64.decode(stored))
-    if (decoded.libType === LibType.DKLS) {
+    if (
+      decoded.libType === LibType.DKLS ||
+      decoded.libType === LibType.KEYIMPORT
+    ) {
       vaultBytes = base64.decode(stored)
     } else if (privateKeyHex) {
       const publicKeyHex = derivePublicKeyHex(privateKeyHex)

--- a/src/services/fastVaultServer.stub.ts
+++ b/src/services/fastVaultServer.stub.ts
@@ -1,6 +1,6 @@
 import type { MpcProtocol } from './fastVaultServer'
 
-export async function setupBatchImport(
+export async function setupBatchKeygen(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- stub retains signature parity with real impl
   _input: {
     name: string
@@ -10,8 +10,42 @@ export async function setupBatchImport(
     local_party_id: string
     encryption_password: string
     email: string
+    lib_type: number
+    protocols: MpcProtocol[]
+  }
+): Promise<void> {
+  // Activated by STUB_VULTISERVER — keeps UI flows offline.
+}
+
+export async function setupBatchImport(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- stub retains signature parity with real impl
+  _input: {
+    name: string
+    session_id: string
+    hex_encryption_key: string
+    local_party_id: string
+    encryption_password: string
+    email: string
+    lib_type?: number
     protocols: MpcProtocol[]
     chains?: string[]
+  }
+): Promise<void> {
+  // Activated by STUB_VULTISERVER — keeps UI flows offline.
+}
+
+export async function setupKeyImport(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- stub retains signature parity with real impl
+  _input: {
+    name: string
+    session_id: string
+    hex_encryption_key: string
+    hex_chain_code: string
+    local_party_id: string
+    encryption_password: string
+    email: string
+    lib_type: number
+    chains: string[]
   }
 ): Promise<void> {
   // Activated by STUB_VULTISERVER — keeps UI flows offline.

--- a/src/services/fastVaultServer.ts
+++ b/src/services/fastVaultServer.ts
@@ -3,15 +3,47 @@ import * as stub from './fastVaultServer.stub'
 
 export type MpcProtocol = 'ecdsa' | 'eddsa'
 
-/** Register a batch import with vultiserver — ECDSA only, no EdDSA required. */
+type BatchVaultBaseInput = {
+  name: string
+  session_id: string
+  hex_encryption_key: string
+  local_party_id: string
+  encryption_password: string
+  email: string
+  protocols: MpcProtocol[]
+}
+
+/** Register a batch keygen with vultiserver. */
+export async function setupBatchKeygen(
+  input: BatchVaultBaseInput & {
+    hex_chain_code: string
+    lib_type: number
+  }
+): Promise<void> {
+  if (STUB_VULTISERVER) return stub.setupBatchKeygen(input)
+
+  const url = `${env.vultisigApiUrl}/vault/batch/keygen`
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`setupBatchKeygen failed: ${res.status} ${text}`)
+  }
+}
+
+/** Register a batch import with vultiserver. */
 export async function setupBatchImport(input: {
   name: string
   session_id: string
   hex_encryption_key: string
-  hex_chain_code: string
   local_party_id: string
   encryption_password: string
   email: string
+  lib_type?: number
   protocols: MpcProtocol[]
   chains?: string[]
 }): Promise<void> {
@@ -27,6 +59,33 @@ export async function setupBatchImport(input: {
   if (!res.ok) {
     const text = await res.text()
     throw new Error(`setupBatchImport failed: ${res.status} ${text}`)
+  }
+}
+
+/** Register a sequential key import with vultiserver. */
+export async function setupKeyImport(input: {
+  name: string
+  session_id: string
+  hex_encryption_key: string
+  hex_chain_code: string
+  local_party_id: string
+  encryption_password: string
+  email: string
+  lib_type: number
+  chains: string[]
+}): Promise<void> {
+  if (STUB_VULTISERVER) return stub.setupKeyImport(input)
+
+  const url = `${env.vultisigApiUrl}/vault/import`
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`setupKeyImport failed: ${res.status} ${text}`)
   }
 }
 

--- a/src/services/migrateToVault.ts
+++ b/src/services/migrateToVault.ts
@@ -13,7 +13,11 @@ import {
 import preferences, {
   PreferencesEnum,
 } from 'nativeModules/preferences'
-import type { KeyImportResult } from './dklsKeyImport'
+import type {
+  CreatedFastVaultResult,
+  ImportedSeedFastVaultResult,
+  KeyImportResult,
+} from './dklsKeyImport'
 
 const VAULT_KEY_PREFIX = 'VAULT-'
 
@@ -39,6 +43,25 @@ export interface MigrationResult {
   wallet: MigrationWallet
   success: boolean
   error?: string
+}
+
+function getUniqueImportedChainKeyShares(
+  importedChains: ImportedSeedFastVaultResult['importedChains']
+): Array<{ publicKey: string; keyshare: string }> {
+  const seenPublicKeys = new Set<string>()
+
+  return importedChains.flatMap((chain) => {
+    if (!chain.keyshare) return []
+    if (seenPublicKeys.has(chain.publicKey)) return []
+    seenPublicKeys.add(chain.publicKey)
+
+    return [
+      {
+        publicKey: chain.publicKey,
+        keyshare: chain.keyshare,
+      },
+    ]
+  })
 }
 
 /**
@@ -80,7 +103,10 @@ export async function getStoredVault(
  */
 export async function storeFastVault(
   walletName: string,
-  result: KeyImportResult
+  result:
+    | KeyImportResult
+    | CreatedFastVaultResult
+    | ImportedSeedFastVaultResult
 ): Promise<void> {
   if (await isVaultFastVault(walletName)) {
     // eslint-disable-next-line no-console -- important diagnostic for double-migration attempts
@@ -90,27 +116,101 @@ export async function storeFastVault(
     return
   }
 
-  const vault = create(VaultSchema, {
-    name: walletName,
-    publicKeyEcdsa: result.publicKey,
-    publicKeyEddsa: '',
-    signers: [result.localPartyId, result.serverPartyId],
-    localPartyId: result.localPartyId,
-    hexChainCode: result.chainCode,
-    resharePrefix: '',
-    libType: LibType.DKLS,
-    keyShares: [
-      { publicKey: result.publicKey, keyshare: result.keyshare },
-    ],
-    chainPublicKeys: [
-      { chain: 'Terra', publicKey: result.publicKey, isEddsa: false },
-    ],
-    createdAt: {
-      seconds: BigInt(Math.floor(Date.now() / 1000)),
-      nanos: 0,
-    },
-    publicKeyMldsa44: '',
-  })
+  const isSeedImportVault = 'importedChains' in result
+  const isCreatedVault =
+    'publicKeyEddsa' in result && !isSeedImportVault
+  const legacyResult = result as KeyImportResult
+
+  const vault = isSeedImportVault
+    ? create(VaultSchema, {
+        name: walletName,
+        publicKeyEcdsa: result.publicKeyEcdsa,
+        publicKeyEddsa: result.publicKeyEddsa,
+        signers: [result.localPartyId, result.serverPartyId],
+        localPartyId: result.localPartyId,
+        hexChainCode: result.chainCode,
+        resharePrefix: '',
+        libType: LibType.KEYIMPORT,
+        keyShares: [
+          {
+            publicKey: result.publicKeyEcdsa,
+            keyshare: result.keyshareEcdsa,
+          },
+          {
+            publicKey: result.publicKeyEddsa,
+            keyshare: result.keyshareEddsa,
+          },
+          ...getUniqueImportedChainKeyShares(result.importedChains),
+        ],
+        chainPublicKeys: result.importedChains.map((chain) => ({
+          chain: chain.chain,
+          publicKey: chain.publicKey,
+          isEddsa: chain.isEddsa,
+        })),
+        createdAt: {
+          seconds: BigInt(Math.floor(Date.now() / 1000)),
+          nanos: 0,
+        },
+        publicKeyMldsa44: '',
+      })
+    : isCreatedVault
+    ? create(VaultSchema, {
+        name: walletName,
+        publicKeyEcdsa: result.publicKeyEcdsa,
+        publicKeyEddsa: result.publicKeyEddsa,
+        signers: [result.localPartyId, result.serverPartyId],
+        localPartyId: result.localPartyId,
+        hexChainCode: result.chainCode,
+        resharePrefix: '',
+        libType: LibType.DKLS,
+        keyShares: [
+          {
+            publicKey: result.publicKeyEcdsa,
+            keyshare: result.keyshareEcdsa,
+          },
+          {
+            publicKey: result.publicKeyEddsa,
+            keyshare: result.keyshareEddsa,
+          },
+        ],
+        chainPublicKeys: [],
+        createdAt: {
+          seconds: BigInt(Math.floor(Date.now() / 1000)),
+          nanos: 0,
+        },
+        publicKeyMldsa44: '',
+      })
+    : create(VaultSchema, {
+        name: walletName,
+        publicKeyEcdsa: legacyResult.publicKey,
+        publicKeyEddsa: '',
+        signers: [
+          legacyResult.localPartyId,
+          legacyResult.serverPartyId,
+        ],
+        localPartyId: legacyResult.localPartyId,
+        hexChainCode: '',
+        resharePrefix: '',
+        libType: LibType.KEYIMPORT,
+        keyShares: [
+          {
+            publicKey: legacyResult.publicKey,
+            keyshare: legacyResult.keyshare,
+          },
+        ],
+        chainPublicKeys: [
+          {
+            chain: 'Terra',
+            publicKey: legacyResult.publicKey,
+            isEddsa: false,
+          },
+        ],
+        createdAt: {
+          seconds: BigInt(Math.floor(Date.now() / 1000)),
+          nanos: 0,
+        },
+        publicKeyMldsa44: '',
+      })
 
   const vaultBytes = toBinary(VaultSchema, vault)
   const encoded = base64.encode(vaultBytes)
@@ -137,7 +237,7 @@ export async function storeFastVault(
           encryptedKey: '',
           password: '',
           ledger: false,
-          terraOnly: true,
+          terraOnly: !isCreatedVault && !isSeedImportVault,
         },
       },
     })
@@ -166,7 +266,10 @@ export async function isVaultFastVault(
   if (!stored) return false
   try {
     const decoded = fromBinary(VaultSchema, base64.decode(stored))
-    return decoded.libType === LibType.DKLS
+    return (
+      decoded.libType === LibType.DKLS ||
+      decoded.libType === LibType.KEYIMPORT
+    )
   } catch {
     return false
   }

--- a/src/services/privateKeyImport.ts
+++ b/src/services/privateKeyImport.ts
@@ -1,0 +1,37 @@
+import { RawKey } from '@terra-money/terra.js'
+
+import { derivePublicKeyHex } from './vaultProto'
+
+export type ValidatedPrivateKey = {
+  privateKeyHex: string
+  publicKeyHex: string
+  terraAddress: string
+}
+
+export function normalizePrivateKey(input: string): string {
+  return input.trim().replace(/^0x/i, '').replace(/\s+/g, '')
+}
+
+export function validatePrivateKey(
+  input: string
+): ValidatedPrivateKey {
+  const privateKeyHex = normalizePrivateKey(input)
+
+  if (!/^[0-9a-fA-F]{64}$/.test(privateKeyHex)) {
+    throw new Error('Private key must be 64 hexadecimal characters.')
+  }
+
+  try {
+    const privateKeyBytes = Buffer.from(privateKeyHex, 'hex')
+    const rawKey = new RawKey(privateKeyBytes)
+    const publicKeyHex = derivePublicKeyHex(privateKeyHex)
+
+    return {
+      privateKeyHex: privateKeyHex.toLowerCase(),
+      publicKeyHex,
+      terraAddress: rawKey.accAddress,
+    }
+  } catch {
+    throw new Error('Invalid secp256k1 private key.')
+  }
+}

--- a/src/services/seedPhraseImport.ts
+++ b/src/services/seedPhraseImport.ts
@@ -1,0 +1,458 @@
+import * as bip39 from 'bip39'
+import { HDKey } from '@scure/bip32'
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+function deriveSlip10Child(
+  key: Uint8Array,
+  chainCode: Uint8Array,
+  index: number
+): Uint8Array {
+  const { hmac } = require('@noble/hashes/hmac.js')
+  const { sha512 } = require('@noble/hashes/sha2.js')
+
+  const data = new Uint8Array(1 + 32 + 4)
+  data[0] = 0
+  data.set(key, 1)
+  new DataView(data.buffer).setUint32(33, index, false)
+
+  return hmac(sha512, chainCode, data)
+}
+
+function clampThenUniformScalar(seed: Uint8Array): Uint8Array {
+  if (seed.length !== 32) {
+    throw new Error('Seed must be 32 bytes for ed25519 clamping')
+  }
+
+  const { sha512 } = require('@noble/hashes/sha2.js')
+  const digest = sha512(seed)
+  const clamped = new Uint8Array(digest.slice(0, 32))
+
+  clamped[0] &= 248
+  clamped[31] &= 63
+  clamped[31] |= 64
+
+  const order = BigInt(
+    '0x1000000000000000000000000000000014DEF9DEA2F79CD65812631A5CF5D3ED'
+  )
+  let scalar = BigInt(0)
+  for (let i = 0; i < 32; i++) {
+    scalar |= BigInt(clamped[i]) << (BigInt(i) * BigInt(8))
+  }
+  scalar %= order
+
+  const result = new Uint8Array(32)
+  for (let i = 0; i < 32; i++) {
+    result[i] = Number((scalar >> (BigInt(i) * BigInt(8))) & 0xffn)
+  }
+  return result
+}
+
+export type SeedImportChain =
+  | 'Bitcoin'
+  | 'Litecoin'
+  | 'Dogecoin'
+  | 'Bitcoin-Cash'
+  | 'Dash'
+  | 'Zcash'
+  | 'Ethereum'
+  | 'Avalanche'
+  | 'BSC'
+  | 'Polygon'
+  | 'Arbitrum'
+  | 'Optimism'
+  | 'Base'
+  | 'Blast'
+  | 'CronosChain'
+  | 'Zksync'
+  | 'Mantle'
+  | 'Hyperliquid'
+  | 'Sei'
+  | 'THORChain'
+  | 'MayaChain'
+  | 'Cosmos'
+  | 'Kujira'
+  | 'Dydx'
+  | 'Osmosis'
+  | 'Noble'
+  | 'Akash'
+  | 'Terra'
+  | 'TerraClassic'
+  | 'Solana'
+  | 'Sui'
+  | 'Ton'
+  | 'Polkadot'
+  | 'Bittensor'
+  | 'Ripple'
+  | 'Tron'
+
+export type SeedImportDerivationGroup = {
+  representativeChain: SeedImportChain
+  chains: SeedImportChain[]
+  isEddsa: boolean
+}
+
+export type SeedMasterKeys = {
+  ecdsaPrivateKey: string
+  ecdsaChainCode: string
+  eddsaPrivateKey: string
+}
+
+export const SEED_IMPORT_DERIVATION_GROUPS: SeedImportDerivationGroup[] =
+  (
+    [
+      'Bitcoin',
+      'Litecoin',
+      'Dogecoin',
+      'Bitcoin-Cash',
+      'Dash',
+      'Zcash',
+      'Ethereum',
+      'Avalanche',
+      'BSC',
+      'Polygon',
+      'Arbitrum',
+      'Optimism',
+      'Base',
+      'Blast',
+      'CronosChain',
+      'Zksync',
+      'Mantle',
+      'Hyperliquid',
+      'Sei',
+      'THORChain',
+      'MayaChain',
+      'Cosmos',
+      'Kujira',
+      'Dydx',
+      'Osmosis',
+      'Noble',
+      'Akash',
+      'Terra',
+      'TerraClassic',
+      'Ripple',
+      'Tron',
+      'Solana',
+      'Sui',
+      'Ton',
+      'Polkadot',
+      'Bittensor',
+    ] as SeedImportChain[]
+  ).map((chain) => ({
+    representativeChain: chain,
+    chains: [chain],
+    isEddsa: isSeedImportEddsaChain(chain),
+  }))
+
+const COIN_TYPES: Record<SeedImportChain, number> = {
+  Bitcoin: 0,
+  Litecoin: 2,
+  Dogecoin: 3,
+  'Bitcoin-Cash': 145,
+  Dash: 5,
+  Zcash: 133,
+  Ethereum: 60,
+  Avalanche: 9000,
+  BSC: 714,
+  Polygon: 966,
+  Arbitrum: 60,
+  Optimism: 60,
+  Base: 60,
+  Blast: 60,
+  CronosChain: 60,
+  Zksync: 60,
+  Mantle: 60,
+  Hyperliquid: 60,
+  Sei: 60,
+  THORChain: 931,
+  MayaChain: 931,
+  Cosmos: 118,
+  Kujira: 118,
+  Dydx: 118,
+  Osmosis: 118,
+  Noble: 118,
+  Akash: 118,
+  Terra: 330,
+  TerraClassic: 330,
+  Solana: 501,
+  Sui: 784,
+  Ton: 607,
+  Polkadot: 354,
+  Bittensor: 354,
+  Ripple: 144,
+  Tron: 195,
+}
+
+const ECDSA_DERIVATION_PATHS: Partial<
+  Record<SeedImportChain, string>
+> = {
+  Bitcoin: "m/84'/0'/0'/0/0",
+  Litecoin: "m/84'/2'/0'/0/0",
+  Dogecoin: "m/44'/3'/0'/0/0",
+  'Bitcoin-Cash': "m/44'/145'/0'/0/0",
+  Dash: "m/44'/5'/0'/0/0",
+  Zcash: "m/44'/133'/0'/0/0",
+  Ethereum: "m/44'/60'/0'/0/0",
+  Avalanche: "m/44'/60'/0'/0/0",
+  BSC: "m/44'/60'/0'/0/0",
+  Polygon: "m/44'/60'/0'/0/0",
+  Arbitrum: "m/44'/60'/0'/0/0",
+  Optimism: "m/44'/60'/0'/0/0",
+  Base: "m/44'/60'/0'/0/0",
+  Blast: "m/44'/60'/0'/0/0",
+  CronosChain: "m/44'/60'/0'/0/0",
+  Zksync: "m/44'/60'/0'/0/0",
+  Mantle: "m/44'/60'/0'/0/0",
+  Hyperliquid: "m/44'/60'/0'/0/0",
+  Sei: "m/44'/60'/0'/0/0",
+  THORChain: "m/44'/931'/0'/0/0",
+  MayaChain: "m/44'/931'/0'/0/0",
+  Cosmos: "m/44'/118'/0'/0/0",
+  Kujira: "m/44'/118'/0'/0/0",
+  Dydx: "m/44'/118'/0'/0/0",
+  Osmosis: "m/44'/118'/0'/0/0",
+  Noble: "m/44'/118'/0'/0/0",
+  Akash: "m/44'/118'/0'/0/0",
+  Terra: "m/44'/330'/0'/0/0",
+  TerraClassic: "m/44'/330'/0'/0/0",
+  Ripple: "m/44'/144'/0'/0/0",
+  Tron: "m/44'/195'/0'/0/0",
+}
+
+const WALLET_CORE_COIN_TYPE_NAMES: Record<SeedImportChain, string> = {
+  Bitcoin: 'bitcoin',
+  Litecoin: 'litecoin',
+  Dogecoin: 'dogecoin',
+  'Bitcoin-Cash': 'bitcoinCash',
+  Dash: 'dash',
+  Zcash: 'zcash',
+  Ethereum: 'ethereum',
+  Avalanche: 'avalancheCChain',
+  BSC: 'smartChain',
+  Polygon: 'polygon',
+  Arbitrum: 'arbitrum',
+  Optimism: 'optimism',
+  Base: 'base',
+  Blast: 'blast',
+  CronosChain: 'cronosChain',
+  Zksync: 'zksync',
+  Mantle: 'mantle',
+  Hyperliquid: 'ethereum',
+  Sei: 'ethereum',
+  THORChain: 'thorchain',
+  MayaChain: 'thorchain',
+  Cosmos: 'cosmos',
+  Kujira: 'kujira',
+  Dydx: 'dydx',
+  Osmosis: 'osmosis',
+  Noble: 'noble',
+  Akash: 'akash',
+  Terra: 'terraV2',
+  TerraClassic: 'terra',
+  Ripple: 'xrp',
+  Tron: 'tron',
+  Solana: 'solana',
+  Sui: 'sui',
+  Ton: 'ton',
+  Polkadot: 'polkadot',
+  Bittensor: 'polkadot',
+}
+
+function isSeedImportEddsaChain(chain: SeedImportChain): boolean {
+  return (
+    chain === 'Solana' ||
+    chain === 'Sui' ||
+    chain === 'Ton' ||
+    chain === 'Polkadot' ||
+    chain === 'Bittensor'
+  )
+}
+
+export function validateSeedPhrase(mnemonic: string): boolean {
+  return bip39.validateMnemonic(mnemonic.trim().toLowerCase())
+}
+
+export function deriveMasterKeys(mnemonic: string): SeedMasterKeys {
+  const normalized = mnemonic.trim().toLowerCase()
+  if (!validateSeedPhrase(normalized)) {
+    throw new Error('Invalid seed phrase')
+  }
+
+  const seed = new Uint8Array(bip39.mnemonicToSeedSync(normalized))
+  const master = HDKey.fromMasterSeed(seed)
+
+  const { hmac } = require('@noble/hashes/hmac.js')
+  const { sha512 } = require('@noble/hashes/sha2.js')
+  const ed25519Seed = new TextEncoder().encode('ed25519 seed')
+  const eddsaMaster = hmac(sha512, ed25519Seed, seed).slice(0, 32)
+
+  return {
+    ecdsaPrivateKey: bytesToHex(master.privateKey!),
+    ecdsaChainCode: bytesToHex(master.chainCode!),
+    eddsaPrivateKey: bytesToHex(clampThenUniformScalar(eddsaMaster)),
+  }
+}
+
+export function deriveChainKey(
+  mnemonic: string,
+  chain: SeedImportChain
+): {
+  privateKey: string
+  chainCode: string
+  isEddsa: boolean
+} {
+  const normalized = mnemonic.trim().toLowerCase()
+  if (!validateSeedPhrase(normalized)) {
+    throw new Error('Invalid seed phrase')
+  }
+
+  const seed = new Uint8Array(bip39.mnemonicToSeedSync(normalized))
+  const coinType = COIN_TYPES[chain]
+
+  if (isSeedImportEddsaChain(chain)) {
+    const { hmac } = require('@noble/hashes/hmac.js')
+    const { sha512 } = require('@noble/hashes/sha2.js')
+    const hardened = 0x80000000
+
+    let digest = hmac(
+      sha512,
+      new TextEncoder().encode('ed25519 seed'),
+      seed
+    )
+    let key = digest.slice(0, 32)
+    let chainCode = digest.slice(32, 64)
+
+    const path =
+      chain === 'Ton'
+        ? [44, coinType, 0]
+        : chain === 'Polkadot' || chain === 'Bittensor'
+        ? [44, coinType, 0, 0, 0]
+        : [44, coinType, 0, 0]
+
+    for (const index of path) {
+      digest = deriveSlip10Child(key, chainCode, index + hardened)
+      key = digest.slice(0, 32)
+      chainCode = digest.slice(32, 64)
+    }
+
+    return {
+      privateKey: bytesToHex(clampThenUniformScalar(key)),
+      chainCode: '',
+      isEddsa: true,
+    }
+  }
+
+  const master = HDKey.fromMasterSeed(seed)
+  const path = ECDSA_DERIVATION_PATHS[chain]
+  if (!path) {
+    throw new Error(`Unsupported ECDSA chain: ${chain}`)
+  }
+  const derived = master.derive(path)
+  return {
+    privateKey: bytesToHex(derived.privateKey!),
+    chainCode: bytesToHex(derived.chainCode!),
+    isEddsa: false,
+  }
+}
+
+export async function deriveChainKeyForImport(
+  mnemonic: string,
+  chain: SeedImportChain
+): Promise<{
+  privateKey: string
+  chainCode: string
+  isEddsa: boolean
+}> {
+  try {
+    const {
+      NativeWalletCore,
+    } = require('@vultisig/walletcore-native')
+    const walletCore = NativeWalletCore.getInstance()
+    const normalized = mnemonic.trim().toLowerCase()
+    const coinTypeName = WALLET_CORE_COIN_TYPE_NAMES[chain]
+    const coinType = walletCore.CoinType[coinTypeName]
+    if (coinType === undefined) {
+      throw new Error(`CoinType not found for chain: ${chain}`)
+    }
+
+    const wallet = walletCore.HDWallet.createWithMnemonic(
+      normalized,
+      ''
+    )
+    try {
+      const key = wallet.getKeyForCoin(coinType)
+      try {
+        const keyData = new Uint8Array(key.data())
+        return {
+          privateKey: bytesToHex(
+            isSeedImportEddsaChain(chain)
+              ? clampThenUniformScalar(keyData)
+              : keyData
+          ),
+          chainCode: '',
+          isEddsa: isSeedImportEddsaChain(chain),
+        }
+      } finally {
+        key.delete?.()
+      }
+    } finally {
+      wallet.delete?.()
+    }
+  } catch {
+    return deriveChainKey(mnemonic, chain)
+  }
+}
+
+export async function deriveChainPublicKeyForImport(
+  mnemonic: string,
+  chain: SeedImportChain
+): Promise<string> {
+  try {
+    const {
+      NativeWalletCore,
+    } = require('@vultisig/walletcore-native')
+    const walletCore = NativeWalletCore.getInstance()
+    const normalized = mnemonic.trim().toLowerCase()
+    const coinTypeName = WALLET_CORE_COIN_TYPE_NAMES[chain]
+    const coinType = walletCore.CoinType[coinTypeName]
+    if (coinType === undefined) {
+      throw new Error(`CoinType not found for chain: ${chain}`)
+    }
+
+    const wallet = walletCore.HDWallet.createWithMnemonic(
+      normalized,
+      ''
+    )
+    try {
+      const key = wallet.getKeyForCoin(coinType)
+      try {
+        const publicKey = isSeedImportEddsaChain(chain)
+          ? key.getPublicKeyEd25519()
+          : key.getPublicKeySecp256k1(true)
+        try {
+          return bytesToHex(new Uint8Array(publicKey.data()))
+        } finally {
+          publicKey.delete?.()
+        }
+      } finally {
+        key.delete?.()
+      }
+    } finally {
+      wallet.delete?.()
+    }
+  } catch {
+    const key = deriveChainKey(mnemonic, chain)
+    if (!key.isEddsa) {
+      throw new Error(
+        `Native WalletCore is required to derive ${chain} public key`
+      )
+    }
+
+    const { ed25519 } = require('@noble/curves/ed25519.js')
+    return bytesToHex(ed25519.getPublicKey(key.privateKey))
+  }
+}


### PR DESCRIPTION
## Description

Fixes Station vault exports so new Station vaults import into Vultisig wallets with the expected derivation model.

- seed phrase recovery now imports root ECDSA + root EdDSA, records per-chain child public keys, and keeps Terra signable with a Terra child keyshare
- new Fast Vault creation now stores root DKLS ECDSA + root EdDSA with chain code, matching Vultisig-created Fast Vaults
- existing private-key / legacy Station migrations stay Terra-only KeyImport vaults, which is the only recoverable in-place migration when Station no longer has the seed/root
- exports now preserve DKLS / KeyImport fields instead of collapsing everything to the old share shape
- adds focused tests for server requests, seed import derivation, vault storage, and share export

## Derivation proof

| Station flow | Exported shape | Cross-app result |
| --- | --- | --- |
| Seed phrase import | `KeyImport`, root ECDSA + root EdDSA, 36 `chainPublicKeys`, Terra child keyshare | Station export imported into vultiagent. Vultisig iOS decoded it as a 36-chain KeyImport vault, and SDK WalletCore derived the expected Vultisig seed addresses from the exported child public keys. |
| New Fast Vault | `DKLS`, root ECDSA + root EdDSA, 64-char chain code, no `chainPublicKeys` | Vultisig iOS decoded it as a root DKLS vault, so Vultisig wallets derive per-chain children from the same root material as a Vultisig-created Fast Vault. |
| Legacy/private-key Station migration | `KeyImport`, Terra child ECDSA keyshare only, one Terra `chainPublicKey` | Station keeps Terra signing available in place. Vultisig iOS decoded it as Terra-only, which is the expected limit because the seed/root is not recoverable from these wallets. |

Artifact shape checks from the exported live `.vult` files:

| Artifact | Decoded fields |
| --- | --- |
| `Seed-Live-Root-station-mobile.vult` | `libType=KeyImport`, `chainPublicKeys=36`, root ECDSA present, root EdDSA present, Terra child keyshare present |
| `Created-Live-Root-station-mobile.vult` | `libType=DKLS`, `chainPublicKeys=0`, `hexChainCode.length=64`, root ECDSA present, root EdDSA present |
| `TestWallet2-migrated-station-mobile.vult` | `libType=KeyImport`, `chainPublicKeys=[Terra]`, EdDSA empty, chain code empty, Terra child keyshare present |

Address samples from the live Station seed export for `abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about`:

| Chain | Address |
| --- | --- |
| Bitcoin | `bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu` |
| Ethereum | `0x9858EfFD232B4033E47d90003D41EC34EcaEda94` |
| THORChain | `thor1gm00vwsfcp48enm4uv9e5dhm37jtd0ye27wrx0` |
| Cosmos | `cosmos19rl4cm2hmr8afy4kldpxz3fka4jguq0auqdal4` |
| Terra / Terra Classic | `terra1amdttz2937a3dytmxmkany53pp6ma6dy4vsllv` |
| Ripple | `rHsMGQEkVNJmpGWs8XUBoTBiAAbwxZN5v3` |
| Solana | `GjJyeC1r2RgkuoCWMyPYkCWSGSGLcz266EaAkLA27AhL` |
| Sui | `0x5e93a736d04fbb25737aa40bee40171ef79f65fae833749e3c089fe7cc2161f1` |
| Ton | `UQAzWZa6nM5mJev91wGc7VCSfBoIsYRqKJpV78N8Add9-RKY` |
| Polkadot | `14E9StbjYhJiAfsNMEcq5tETq79Q6EqaGyebdziY214hNWDH` |
| Bittensor | `5FHrJZLfgv3Ej8rrPbZpwjQJyV9kPwHSCUv7UhjBTv3BCHcc` |

The migrated legacy Terra vault derives `terra1q6hag67dl53wl99vzg42z8eyzfz2xlkvk8uu5v` from its exported Terra public key.

## Verification

- `npm test -- --runInBand`
- `npm run lint:check`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- live Station iOS simulator seed import, created Fast Vault, and in-place Terra migration against Vultiserver
- SDK WalletCore address proof from the exported Station seed vault matched the Vultisig seed addresses for sampled ECDSA + EdDSA chains
- imported the Station seed vault into vultiagent on a separate simulator; verification screen showed `all-passed: true` with imported name, pubkey, keyshare, libtype, and signers present
- temporary Vultisig iOS XCTest decoded all three Station exports and confirmed: 36-chain seed KeyImport, root DKLS created vault, Terra-only migrated KeyImport; `Executed 3 tests, with 0 failures`

## Runtime proof

| Flow | Receipt |
| --- | --- |
| Station seed import share sheet | ![station seed import](https://files.catbox.moe/vbiufr.png) |
| Station created Fast Vault share sheet | ![station created fast vault](https://files.catbox.moe/szv04k.png) |
| Station in-place Terra migration share sheet | ![station migrated terra](https://files.catbox.moe/a4qo06.png) |
| vultiagent import verification | ![vultiagent import verification](https://files.catbox.moe/hcvjz3.png) |
| vultiagent wallet list after import | ![vultiagent wallet list](https://files.catbox.moe/ghx6mc.png) |

## Notes

The derivation regression came from routing seed recovery/create through the private-key import path and importing only the Terra child key. This PR keeps existing Terra-only vaults signable, but it cannot turn those legacy vaults into real multichain wallets in place because Station no longer has the original seed/root material.

During live seed import, the first root ECDSA ceremony returned `dkls_keygen_session_finish failed with error code 1`; retry succeeded. I treated that as server ceremony flakiness rather than a local derivation issue.

<img width="202" height="42" alt="Screenshot 2026-05-08 at 2 54 44 pm" src="https://github.com/user-attachments/assets/bccefb37-68f8-43fc-9b7d-c31dd2bafda7" />
