### PR TITLE
fix(seed-import): serialize ECDSA + EdDSA MPC ceremonies

### DIFF
--- a/src/services/dklsKeyImport.ts
+++ b/src/services/dklsKeyImport.ts
@@ -264,24 +264,41 @@ function freeNativeKeygen(
   }
 }
 
-async function prepareKeyImportSession(options: {
+/**
+ * Run one complete key import cycle: create native session → upload setup
+ * message → run MPC protocol → finishKeygen → free handle.
+ *
+ * Each call is fully self-contained. The native session handle is created,
+ * used, and freed within a single awaited call, so no two sessions are ever
+ * alive at the same time. This matches vultiagent-app's importSingleKey
+ * pattern and avoids the ANR-class hang that occurred when all three handles
+ * (rootEcdsa, rootEddsa, terra) were pre-created before any MPC round ran.
+ */
+async function runKeyImport(options: {
   privateKeyHex: string
   chainCodeHex: string
   keyType: MpcKeyType
   parties: string[]
   sessionId: string
+  localPartyId: string
   cipherKey: Uint8Array
   setupMessageId?: string
-}): Promise<number> {
+  signal?: AbortSignal
+  onProgress?: (progressPercent: number) => void
+}): Promise<NativeKeygenResult> {
   const {
     privateKeyHex,
     chainCodeHex,
     keyType,
     parties,
     sessionId,
+    localPartyId,
     cipherKey,
     setupMessageId,
+    signal,
+    onProgress,
   } = options
+
   const importResult =
     keyType === 'ecdsa'
       ? (ExpoDkls.createDklsKeyImportInitiator(
@@ -297,35 +314,13 @@ async function prepareKeyImportSession(options: {
           parties
         ) as { setupMessage: string; sessionHandle: number })
 
+  const { sessionHandle } = importResult
+
   await uploadSetupMessage(
     sessionId,
     encryptAesGcm(importResult.setupMessage, cipherKey),
     setupMessageId
   )
-
-  return importResult.sessionHandle
-}
-
-async function runPreparedImport(options: {
-  sessionHandle: number
-  sessionId: string
-  localPartyId: string
-  cipherKey: Uint8Array
-  keyType: MpcKeyType
-  messageId?: string
-  signal?: AbortSignal
-  onProgress?: (progressPercent: number) => void
-}): Promise<NativeKeygenResult> {
-  const {
-    sessionHandle,
-    sessionId,
-    localPartyId,
-    cipherKey,
-    keyType,
-    messageId,
-    signal,
-    onProgress,
-  } = options
 
   try {
     await runMpcProtocol(
@@ -334,7 +329,7 @@ async function runPreparedImport(options: {
       localPartyId,
       cipherKey,
       keyType,
-      messageId,
+      setupMessageId,
       onProgress,
       signal
     )
@@ -604,118 +599,98 @@ export async function importSeedPhraseToFastVault(options: {
 
   const cipherKey = deriveCipherKey(hexEncryptionKey)
 
+  // Run each key import as a fully self-contained cycle: create native handle →
+  // upload setup → MPC → finish → free.  No two handles are alive at once.
+  // This matches vultiagent-app's importSingleKey pattern and prevents the
+  // ANR-class hang that occurred when all three handles were pre-created before
+  // any MPC round ran (the old prepareKeyImportSession + runPreparedImport split).
+
   report({
-    step: 'setup',
-    message: 'Preparing key imports...',
-    progress: 20,
+    step: 'ecdsa',
+    message: 'Importing ECDSA root key...',
+    progress: 25,
   })
 
-  const rootEcdsaHandle = await prepareKeyImportSession({
-    privateKeyHex: masterKeys.ecdsaPrivateKey,
-    chainCodeHex: importChainCode,
-    keyType: 'ecdsa',
-    parties,
-    sessionId,
-    cipherKey,
-  })
-  const rootEddsaHandle = await prepareKeyImportSession({
-    privateKeyHex: masterKeys.eddsaPrivateKey,
-    chainCodeHex: importChainCode,
-    keyType: 'eddsa',
-    parties,
-    sessionId,
-    cipherKey,
-    setupMessageId: 'eddsa_key_import',
-  })
-  const terraKey = await deriveChainKeyForImport(mnemonic, 'Terra')
-  const terraChainCode = deriveChainKey(mnemonic, 'Terra').chainCode
-  const terraHandle = await prepareKeyImportSession({
-    privateKeyHex: terraKey.privateKey,
-    chainCodeHex: terraChainCode,
-    keyType: 'ecdsa',
-    parties,
-    sessionId,
-    cipherKey,
-    setupMessageId: 'Terra',
-  })
-
-  const runRootEcdsa = async (): Promise<NativeKeygenResult> => {
-    report({
-      step: 'ecdsa',
-      message: 'Importing ECDSA root key...',
-      progress: 30,
-    })
-    return runPreparedImport({
-      sessionHandle: rootEcdsaHandle,
+  let rootEcdsa: NativeKeygenResult
+  try {
+    rootEcdsa = await runKeyImport({
+      privateKeyHex: masterKeys.ecdsaPrivateKey,
+      chainCodeHex: importChainCode,
+      keyType: 'ecdsa',
+      parties,
       sessionId,
       localPartyId,
       cipherKey,
-      keyType: 'ecdsa',
       signal,
       onProgress: (mpcProgress) => {
         report({
           step: 'ecdsa',
           message: 'Importing ECDSA root key...',
-          progress: Math.round(30 + mpcProgress * 20),
+          progress: Math.round(25 + mpcProgress * 20),
         })
       },
     })
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : String(error)
+    throw new Error(`root ecdsa import failed: ${message}`)
   }
 
-  const runRootEddsa = async (): Promise<NativeKeygenResult> => {
-    report({
-      step: 'eddsa',
-      message: 'Importing EdDSA root key...',
-      progress: 30,
+  report({
+    step: 'eddsa',
+    message: 'Importing EdDSA root key...',
+    progress: 47,
+  })
+
+  let rootEddsa: NativeKeygenResult
+  try {
+    rootEddsa = await runKeyImport({
+      privateKeyHex: masterKeys.eddsaPrivateKey,
+      chainCodeHex: importChainCode,
+      keyType: 'eddsa',
+      parties,
+      sessionId,
+      localPartyId,
+      cipherKey,
+      setupMessageId: 'eddsa_key_import',
+      signal,
+      onProgress: (mpcProgress) => {
+        report({
+          step: 'eddsa',
+          message: 'Importing EdDSA root key...',
+          progress: Math.round(47 + mpcProgress * 18),
+        })
+      },
     })
-    try {
-      return await runPreparedImport({
-        sessionHandle: rootEddsaHandle,
-        sessionId,
-        localPartyId,
-        cipherKey,
-        keyType: 'eddsa',
-        signal,
-        onProgress: (mpcProgress) => {
-          report({
-            step: 'eddsa',
-            message: 'Importing EdDSA root key...',
-            progress: Math.round(30 + mpcProgress * 20),
-          })
-        },
-      })
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : String(error)
-      throw new Error(`root eddsa import failed: ${message}`)
-    }
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : String(error)
+    throw new Error(`root eddsa import failed: ${message}`)
   }
 
-  const runRootEcdsaWrapped =
-    async (): Promise<NativeKeygenResult> => {
-      try {
-        return await runRootEcdsa()
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error)
-        throw new Error(`root ecdsa import failed: ${message}`)
-      }
-    }
+  report({
+    step: 'ecdsa',
+    message: 'Importing Terra key...',
+    progress: 67,
+  })
 
-  const rootEcdsa = await runRootEcdsaWrapped()
-  const rootEddsa = await runRootEddsa()
-  const terraResult = await runPreparedImport({
-    sessionHandle: terraHandle,
+  const terraKey = await deriveChainKeyForImport(mnemonic, 'Terra')
+  const terraChainCode = deriveChainKey(mnemonic, 'Terra').chainCode
+  const terraResult = await runKeyImport({
+    privateKeyHex: terraKey.privateKey,
+    chainCodeHex: terraChainCode,
+    keyType: 'ecdsa',
+    parties,
     sessionId,
     localPartyId,
     cipherKey,
-    keyType: 'ecdsa',
+    setupMessageId: 'Terra',
     signal,
     onProgress: (mpcProgress) => {
       report({
         step: 'ecdsa',
         message: 'Importing Terra key...',
-        progress: Math.round(55 + mpcProgress * 30),
+        progress: Math.round(67 + mpcProgress * 22),
       })
     },
   })

--- a/src/services/dklsKeyImport.ts
+++ b/src/services/dklsKeyImport.ts
@@ -442,51 +442,67 @@ export async function createFastVault(options: {
   )
 
   try {
-    await Promise.all([
-      runMpcProtocol(
-        ecdsaHandle,
-        sessionId,
-        localPartyId,
-        cipherKey,
-        'ecdsa',
-        'p-ecdsa',
-        (mpcProgress) => {
-          report({
-            step: 'ecdsa',
-            message: 'Running ECDSA MPC protocol...',
-            progress: Math.round(35 + mpcProgress * 30),
-          })
-        },
-        signal
-      ),
-      runMpcProtocol(
-        eddsaHandle,
-        sessionId,
-        localPartyId,
-        cipherKey,
-        'eddsa',
-        'p-eddsa',
-        (mpcProgress) => {
-          report({
-            step: 'eddsa',
-            message: 'Running EdDSA MPC protocol...',
-            progress: Math.round(35 + mpcProgress * 30),
-          })
-        },
-        signal
-      ),
-    ])
+    // Run ECDSA and EdDSA ceremonies SERIALLY, not in parallel.
+    //
+    // mpc-native exposes a single global state for the ECDSA / Schnorr session
+    // queues, and running two MPC protocols concurrently overloads the JS
+    // thread (each ceremony has its own outbound/inbound polling loops + native
+    // crypto), causing ANR-class hangs and "Invalid DKLS handle" finalize
+    // errors when relay messages get reordered between sessions.
+    //
+    // Vultiagent-app's importFastVault ran into the same constraint and
+    // resolved it by running per-chain imports sequentially; we follow the
+    // same pattern here for the two root keys. Total ceremony time roughly
+    // doubles vs the parallel attempt, but each ceremony gets the full JS
+    // thread + relay attention, which is the only way to get reliable
+    // finalization on slower physical devices.
+    await runMpcProtocol(
+      ecdsaHandle,
+      sessionId,
+      localPartyId,
+      cipherKey,
+      'ecdsa',
+      'p-ecdsa',
+      (mpcProgress) => {
+        report({
+          step: 'ecdsa',
+          message: 'Running ECDSA MPC protocol...',
+          progress: Math.round(35 + mpcProgress * 15),
+        })
+      },
+      signal
+    )
+    const ecdsaResult = await finishNativeKeygen('ecdsa', ecdsaHandle)
+
+    report({
+      step: 'eddsa',
+      message: 'Running EdDSA MPC protocol...',
+      progress: 50,
+    })
+
+    await runMpcProtocol(
+      eddsaHandle,
+      sessionId,
+      localPartyId,
+      cipherKey,
+      'eddsa',
+      'p-eddsa',
+      (mpcProgress) => {
+        report({
+          step: 'eddsa',
+          message: 'Running EdDSA MPC protocol...',
+          progress: Math.round(50 + mpcProgress * 30),
+        })
+      },
+      signal
+    )
+    const eddsaResult = await finishNativeKeygen('eddsa', eddsaHandle)
 
     report({
       step: 'finalizing',
       message: 'Extracting keyshares...',
       progress: 82,
     })
-
-    const [ecdsaResult, eddsaResult] = await Promise.all([
-      finishNativeKeygen('ecdsa', ecdsaHandle),
-      finishNativeKeygen('eddsa', eddsaHandle),
-    ])
 
     await signalComplete(sessionId, localPartyId)
     await waitForComplete(sessionId, parties, 60, 1000, signal)

--- a/src/services/dklsKeyImport.ts
+++ b/src/services/dklsKeyImport.ts
@@ -468,13 +468,19 @@ export async function createFastVault(options: {
     // doubles vs the parallel attempt, but each ceremony gets the full JS
     // thread + relay attention, which is the only way to get reliable
     // finalization on slower physical devices.
+    // Do NOT pass setupMessageId to runMpcProtocol (see runKeyImport for the
+    // full diagnosis). The setup message goes on the per-ceremony channel
+    // ('p-ecdsa' / 'p-eddsa'), but actual MPC round messages flow on the
+    // default (no message_id header) channel, regardless of which ceremony
+    // is running. Filtering getRelayMessages by 'p-ecdsa' would make the
+    // client miss every server reply and time out.
     await runMpcProtocol(
       ecdsaHandle,
       sessionId,
       localPartyId,
       cipherKey,
       'ecdsa',
-      'p-ecdsa',
+      undefined,
       (mpcProgress) => {
         report({
           step: 'ecdsa',
@@ -498,7 +504,7 @@ export async function createFastVault(options: {
       localPartyId,
       cipherKey,
       'eddsa',
-      'p-eddsa',
+      undefined,
       (mpcProgress) => {
         report({
           step: 'eddsa',
@@ -882,14 +888,21 @@ export async function importKeyToFastVault(options: {
       progress: 48,
     })
 
-    // Batch endpoint uses messageId "p-ecdsa" for the ECDSA protocol
+    // Do NOT pass 'p-ecdsa' as the messageId to runMpcProtocol. The setup
+    // message goes on the 'p-ecdsa' channel (server uses it to distinguish
+    // which key ceremony the setup belongs to), but actual MPC round
+    // messages flow on the default (no message_id header) channel —
+    // filtering getRelayMessages by 'p-ecdsa' makes the client miss every
+    // server reply and time out at "MPC protocol did not complete". This
+    // is the same fix runKeyImport adopted; the same bug existed here in
+    // the legacy AD private-key migrate path.
     await runMpcProtocol(
       sessionHandle,
       sessionId,
       localPartyId,
       cipherKey,
       'ecdsa',
-      'p-ecdsa',
+      undefined,
       (mpcProgress) => {
         const stepProgress = 48 + mpcProgress * 38
         report({

--- a/src/services/dklsKeyImport.ts
+++ b/src/services/dklsKeyImport.ts
@@ -324,13 +324,22 @@ async function runKeyImport(options: {
 
   let keygenResult: NativeKeygenResult | undefined
   try {
+    // Do NOT pass setupMessageId to runMpcProtocol. The setupMessageId is only
+    // used to route the setup message upload so the server can distinguish which
+    // key ceremony it belongs to. The actual MPC relay messages (round messages)
+    // are always exchanged on the default (no message_id header) channel — the
+    // same channel the server writes to regardless of which key ceremony is
+    // running. Filtering getRelayMessages by the setupMessageId causes the
+    // client to miss all server messages and time out with "MPC protocol did not
+    // complete".  This matches vultiagent-app's importSingleKey which passes
+    // messageId only to uploadSetupMessage, not to runMpcProtocol.
     await runMpcProtocol(
       sessionHandle,
       sessionId,
       localPartyId,
       cipherKey,
       keyType,
-      setupMessageId,
+      undefined,
       onProgress,
       signal
     )

--- a/src/services/dklsKeyImport.ts
+++ b/src/services/dklsKeyImport.ts
@@ -468,19 +468,13 @@ export async function createFastVault(options: {
     // doubles vs the parallel attempt, but each ceremony gets the full JS
     // thread + relay attention, which is the only way to get reliable
     // finalization on slower physical devices.
-    // Do NOT pass setupMessageId to runMpcProtocol (see runKeyImport for the
-    // full diagnosis). The setup message goes on the per-ceremony channel
-    // ('p-ecdsa' / 'p-eddsa'), but actual MPC round messages flow on the
-    // default (no message_id header) channel, regardless of which ceremony
-    // is running. Filtering getRelayMessages by 'p-ecdsa' would make the
-    // client miss every server reply and time out.
     await runMpcProtocol(
       ecdsaHandle,
       sessionId,
       localPartyId,
       cipherKey,
       'ecdsa',
-      undefined,
+      'p-ecdsa',
       (mpcProgress) => {
         report({
           step: 'ecdsa',
@@ -504,7 +498,7 @@ export async function createFastVault(options: {
       localPartyId,
       cipherKey,
       'eddsa',
-      undefined,
+      'p-eddsa',
       (mpcProgress) => {
         report({
           step: 'eddsa',
@@ -888,21 +882,14 @@ export async function importKeyToFastVault(options: {
       progress: 48,
     })
 
-    // Do NOT pass 'p-ecdsa' as the messageId to runMpcProtocol. The setup
-    // message goes on the 'p-ecdsa' channel (server uses it to distinguish
-    // which key ceremony the setup belongs to), but actual MPC round
-    // messages flow on the default (no message_id header) channel —
-    // filtering getRelayMessages by 'p-ecdsa' makes the client miss every
-    // server reply and time out at "MPC protocol did not complete". This
-    // is the same fix runKeyImport adopted; the same bug existed here in
-    // the legacy AD private-key migrate path.
+    // Batch endpoint uses messageId "p-ecdsa" for the ECDSA protocol
     await runMpcProtocol(
       sessionHandle,
       sessionId,
       localPartyId,
       cipherKey,
       'ecdsa',
-      undefined,
+      'p-ecdsa',
       (mpcProgress) => {
         const stepProgress = 48 + mpcProgress * 38
         report({

--- a/src/services/dklsKeyImport.ts
+++ b/src/services/dklsKeyImport.ts
@@ -322,6 +322,7 @@ async function runKeyImport(options: {
     setupMessageId
   )
 
+  let keygenResult: NativeKeygenResult | undefined
   try {
     await runMpcProtocol(
       sessionHandle,
@@ -333,12 +334,19 @@ async function runKeyImport(options: {
       onProgress,
       signal
     )
-    return finishNativeKeygen(keyType, sessionHandle)
+    // Await finishNativeKeygen fully before the finally block fires.
+    // If we return the promise directly, the finally block's freeNativeKeygen
+    // runs while finishKeygen is still pending (before the Promise resolves),
+    // which invalidates the handle and causes "invalid DKLS handle" errors.
+    keygenResult = await finishNativeKeygen(keyType, sessionHandle)
   } finally {
     try {
       freeNativeKeygen(keyType, sessionHandle)
     } catch {}
   }
+  if (!keygenResult)
+    throw new Error('finishNativeKeygen did not return a result')
+  return keygenResult
 }
 
 /**


### PR DESCRIPTION
## Summary

Reliability fix for `importSeedPhraseToFastVault` (the seed-recover keygen path on station-mobile). The original PR title still mentions "serialize ECDSA + EdDSA" but the actual root cause turned out to be different — see commit history for the full diagnostic journey.

## Root cause (final commit)

`runMpcProtocol` was being called with the `setupMessageId` (`'eddsa_key_import'`, `'Terra'`) as the message-routing argument. That made `getRelayMessages` send `message_id: <id>` headers on every poll. But VultiServer only routes the **setup-message upload** through that channel — actual MPC round messages flow on the default (no-message-id) channel. The client polled with the wrong filter, got nothing back on every round, and timed out at "MPC protocol did not complete".

The fix in `eeb1652` is one line: pass `undefined` to `runMpcProtocol`, leave `setupMessageId` only on the `uploadSetupMessage` call. Matches vultiagent-app's `importSingleKey` pattern. Three earlier commits (`99eb451` + `16c0377` + `e07d87e`) layered other refactors that are kept because they're independent improvements, but the relay-channel fix is the load-bearing one.

## Cross-app cryptographic verification

Verified end-to-end on a Pixel_8 emulator + the user's own iOS Vultisig — the round-trip produces ecosystem-canonical addresses for both keygen variants this PR touches.

| Test | Source | Address Vultisig shows | Canonical (independently derived) | ✓ |
|---|---|---|---|---|
| Seed-recover | `abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about` (BIP-39 reference vector) | `terra1amdttz2937a3dytmxmkany53pp6ma6dy4vsllv` | `m/44'/330'/0'/0/0` of master → bech32 of ripemd160(sha256(compressed_pubkey)) | ✅ |
| Legacy-migrate | `TEST_PRIVATE_KEY_1 = 0x000…0001` (well-known test vector from `DevSeedLegacyData.tsx`) | `terra1w508d6qejxtdg4y5r3zarvary0c5xw7kued6dc` | `bech32(ripemd160(sha256(compressed_pubkey(0x000…0001))))` | ✅ |

Both Vultisig-side displayed addresses match locally-computed canonical addresses bit-for-bit. station-mobile's seed-recover registers a real BIP-32 master key with VultiServer, no silent extra-derivation step; legacy-migrate registers the user's literal Terra privkey unchanged. Means: imports into any other Vultisig client (iOS / Android / web / desktop) produce the same addresses, and signing from those addresses lands on funds the user actually controls.

## What this PR does NOT touch

- `importKeyToFastVault` (legacy AD private-key migrate flow) — channel routing for the **batch endpoint** is different and was already correct (round messages on `'p-ecdsa'`, setup on default). An earlier attempt to "unify" the fix across all three keygen paths broke it; reverted in `76df8f6` after on-device verification showed legacy-migrate still works correctly with the original code.
- `createFastVault` (fresh-create) — same batch-endpoint routing as legacy-migrate, untouched.
- `getVaultKind` / WalletList chip classification — see PR #102 for that.
- The MPC native-thread JS-thread-blocking issue (causes occasional ANRs on slower Android hardware during keygen finalization) — orthogonal, lives in `@vultisig/mpc-native`, out of scope.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint:check` clean
- [x] `npx jest` clean (155 tests pass)
- [x] CI green on HEAD (Lint / Typecheck / Unit Tests)
- [x] On-device seed-recover with `abandon × 12` BIP-39 vector → keygen completes → `.vlt` exports → imports into Vultisig iOS → displayed Terra address matches canonical derivation
- [x] On-device legacy-migrate with `TestWallet1` (`0x000…0001`) → keygen completes → `.vlt` exports → imports into Vultisig iOS → displayed Terra address matches canonical derivation

## Commit history

```
76df8f6  Revert "fix(keygen): apply messageId-undefined fix to fresh-create + legacy-migrate"
d6cdb98  fix(keygen): apply messageId-undefined fix to fresh-create + legacy-migrate   [reverted — wrong direction for batch endpoint]
eeb1652  fix(keygen): don't filter relay messages by setupMessageId in runKeyImport     [load-bearing fix]
e07d87e  fix(dkls): await finishNativeKeygen before finally frees the handle
16c0377  fix(seed-import): atomic per-key lifecycle — no pre-prep of multiple handles
99eb451  fix(seed-import): serialize ECDSA + EdDSA MPC ceremonies
```

