### PR TITLE
Remove private key import from bypass auth screen

### DIFF
--- a/src/screens/auth/AuthMenu.tsx
+++ b/src/screens/auth/AuthMenu.tsx
@@ -22,7 +22,6 @@ const AuthMenu = ({
     goToMigration,
     startCreateVault,
     startImportVault,
-    startImportPrivateKey,
     startSeedRecoveryInput,
   } = useWalletNav()
   const insets = useSafeAreaInsets()
@@ -83,16 +82,6 @@ const AuthMenu = ({
           >
             <Text style={styles.secondaryButtonText}>
               Import Fast Vault
-            </Text>
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            testID="auth-import-private-key"
-            style={styles.secondaryButton}
-            onPress={startImportPrivateKey}
-          >
-            <Text style={styles.secondaryButtonText}>
-              Import Private Key
             </Text>
           </TouchableOpacity>
 


### PR DESCRIPTION
## Description

Removes `Import Private Key` from the dev/bypass `AuthMenu` screen.

The production entry point is the initial migration flow: `Enter the Vultiverse` -> `Import wallet` -> `Import private key`. That path already exists from #95, so this keeps the bypass screen from looking like the canonical entry point.

@NeOMakinG tagging you here since this is a follow-up to the private-key import PR.

## Verification

- `npm run typecheck -- --pretty false`
- `npm run lint:check`
- `git diff --check`

## Runtime proof

Tested on iOS simulator `Station Private Key Runtime` after erasing simulator state and launching without `EXPO_PUBLIC_BYPASS_AUTH_FOR_TESTING`.

- Confirmed fresh install opens the production migration intro.
- Tapped `Enter the Vultiverse`.
- Tapped `Import wallet`.
- Confirmed the sheet exposes `Import private key`.

<img src="https://files.catbox.moe/mqiam0.png" width="260" />
