### PR TITLE
Add Terra-only private key import flow

### DIFF
--- a/__tests__/wallet/private-key-import.test.ts
+++ b/__tests__/wallet/private-key-import.test.ts
@@ -1,0 +1,41 @@
+import {
+  normalizePrivateKey,
+  validatePrivateKey,
+} from 'services/privateKeyImport'
+
+describe('private key import validation', () => {
+  const privateKey =
+    '0000000000000000000000000000000000000000000000000000000000000002'
+
+  it('normalizes 0x-prefixed private keys with whitespace', () => {
+    expect(
+      normalizePrivateKey(
+        `  0x${privateKey.slice(0, 32)}  ${privateKey.slice(32)}  `
+      )
+    ).toBe(privateKey)
+  })
+
+  it('derives the Terra address for a valid private key', () => {
+    const result = validatePrivateKey(privateKey)
+
+    expect(result.privateKeyHex).toBe(privateKey)
+    expect(result.publicKeyHex).toBe(
+      '02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5'
+    )
+    expect(result.terraAddress).toBe(
+      'terra1q6hag67dl53wl99vzg42z8eyzfz2xlkvk8uu5v'
+    )
+  })
+
+  it('rejects malformed private keys', () => {
+    expect(() => validatePrivateKey('not-a-key')).toThrow(
+      /64 hexadecimal/i
+    )
+  })
+
+  it('rejects invalid secp256k1 private keys', () => {
+    expect(() => validatePrivateKey('0'.repeat(64))).toThrow(
+      /Invalid secp256k1/i
+    )
+  })
+})

--- a/__tests__/wallet/vault-store.test.ts
+++ b/__tests__/wallet/vault-store.test.ts
@@ -4,6 +4,7 @@ import { base64 } from '@scure/base'
 import { __reset as resetSecure } from '../__mocks__/expo-secure-store'
 import { persistImportedVault } from 'services/importVaultBackup'
 import { getStoredVault, storeFastVault } from 'services/migrateToVault'
+import { getAuthData } from 'utils/authData'
 import { VaultSchema } from '../../src/proto/vultisig/vault/v1/vault_pb'
 import { LibType } from '../../src/proto/vultisig/keygen/v1/lib_type_message_pb'
 
@@ -97,6 +98,12 @@ describe('storeFastVault', () => {
     ).toEqual([
       { chain: 'Terra', publicKey: '02terra', isEddsa: false },
     ])
+
+    const authData = await getAuthData()
+    expect(authData?.TerraOnly).toMatchObject({
+      ledger: false,
+      terraOnly: true,
+    })
   })
 
   it('stores newly created fast vaults as DKLS root ECDSA plus EdDSA vaults', async () => {

--- a/src/components/AddWalletSheet.tsx
+++ b/src/components/AddWalletSheet.tsx
@@ -74,12 +74,33 @@ function VaultShareIcon(): React.ReactElement {
   )
 }
 
+function KeyIcon(): React.ReactElement {
+  return (
+    <Svg width={20} height={20} viewBox="0 0 20 20" fill="none">
+      <Circle
+        cx={7}
+        cy={10}
+        r={3}
+        stroke={ICON_BLUE}
+        strokeWidth={1.5}
+      />
+      <Path
+        d="M10 10h7M14 10v3M17 10v2"
+        stroke={ICON_BLUE}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+      />
+    </Svg>
+  )
+}
+
 type Props = {
   visible: boolean
   onDismiss: () => void
   onCreate: () => void
   onRecover: () => void
   onImport: () => void
+  onImportPrivateKey: () => void
   // When false, the "Create new wallet" card is hidden. Used by the
   // import-wallet entry on MigrationHome where the user already declared
   // they have an existing wallet — Create would just be a misroute.
@@ -92,6 +113,7 @@ export default function AddWalletSheet({
   onCreate,
   onRecover,
   onImport,
+  onImportPrivateKey,
   showCreate = true,
 }: Props): React.ReactElement {
   const insets = useSafeAreaInsets()
@@ -220,6 +242,31 @@ export default function AddWalletSheet({
             >
               Enter your seed phrase to recover or convert a legacy
               wallet into a vault.
+            </Text>
+          </Pressable>
+
+          {/* Import private key card */}
+          <Pressable
+            testID="add-wallet-import-private-key"
+            accessibilityRole="button"
+            accessibilityLabel="Import private key"
+            style={styles.card}
+            onPress={dismissAnd(onImportPrivateKey)}
+          >
+            <View style={styles.cardTitleRow}>
+              <KeyIcon />
+              <Text
+                fontType="brockmann-medium"
+                style={styles.cardTitle}
+              >
+                Import private key
+              </Text>
+            </View>
+            <Text
+              fontType="brockmann-medium"
+              style={styles.cardSubtitle}
+            >
+              Convert a Terra private key into a Terra-only vault.
             </Text>
           </Pressable>
 

--- a/src/navigation/MigrationNavigator.tsx
+++ b/src/navigation/MigrationNavigator.tsx
@@ -14,6 +14,7 @@ import BackupVault from '../screens/migration/BackupScreen'
 import ImportVault from '../screens/migration/ImportVault'
 import MigrationSuccess from '../screens/migration/MigrationSuccess'
 import RecoverSeed from '../screens/migration/RecoverSeed'
+import ImportPrivateKey from '../screens/migration/ImportPrivateKey'
 
 // Lazy-load KeygenProgress — it statically imports rive-react-native which
 // initialises its native runtime on import, keeping the iOS main run loop busy
@@ -43,7 +44,11 @@ import type {
   KeyImportResult,
 } from 'services/dklsKeyImport'
 
-export type MigrationMode = 'migrate' | 'create' | 'recover-seed'
+export type MigrationMode =
+  | 'migrate'
+  | 'create'
+  | 'recover-seed'
+  | 'import-private-key'
 
 import { DevFlags } from '../config/env'
 
@@ -61,17 +66,22 @@ export type MigrationStackParams = {
   VaultSetup: undefined
   WalletsFound: undefined
   VaultName: { mode?: MigrationMode } | undefined
+  ImportPrivateKey: {
+    walletName: string
+  }
   VaultEmail: {
     walletName: string
     wallets?: MigrationWallet[]
     mode: MigrationMode
     email?: string
+    privateKeyHex?: string
   }
   VaultPassword: {
     walletName: string
     wallets?: MigrationWallet[]
     mode: MigrationMode
     email: string
+    privateKeyHex?: string
   }
   KeygenProgress: {
     walletName: string
@@ -81,6 +91,7 @@ export type MigrationStackParams = {
     mode: MigrationMode
     email: string
     password: string
+    privateKeyHex?: string
   }
   VerifyEmail: {
     walletName: string
@@ -121,6 +132,7 @@ type MigrationEntry =
   | 'create-vault'
   | 'recover-seed-input'
   | 'import-vault'
+  | 'import-private-key'
 
 export default function MigrationNavigator({
   initialEntry = 'default',
@@ -132,12 +144,16 @@ export default function MigrationNavigator({
       ? 'VaultName'
       : initialEntry === 'import-vault'
       ? 'ImportVault'
+      : initialEntry === 'import-private-key'
+      ? 'VaultName'
       : initialEntry === 'recover-seed-input'
       ? 'RecoverSeed'
       : 'RiveIntro'
   const vaultNameInitialParams =
     initialEntry === 'create-vault'
       ? { mode: 'create' as const }
+      : initialEntry === 'import-private-key'
+      ? { mode: 'import-private-key' as const }
       : undefined
 
   return (
@@ -164,6 +180,10 @@ export default function MigrationNavigator({
         initialParams={vaultNameInitialParams}
       />
       <Stack.Screen name="VaultEmail" component={VaultEmail} />
+      <Stack.Screen
+        name="ImportPrivateKey"
+        component={ImportPrivateKey}
+      />
       <Stack.Screen name="VaultPassword" component={VaultPassword} />
       <Stack.Screen
         name="KeygenProgress"

--- a/src/navigation/hooks.ts
+++ b/src/navigation/hooks.ts
@@ -13,6 +13,7 @@ export interface WalletNav {
    */
   startSeedRecoveryInput: () => void
   startImportVault: () => void
+  startImportPrivateKey: () => void
   wallets: LocalWallet[]
   refreshWallets: () => Promise<void>
 }
@@ -25,6 +26,7 @@ export const WalletNavContext = createContext<WalletNav>({
   startCreateVault: (): void => {},
   startSeedRecoveryInput: (): void => {},
   startImportVault: (): void => {},
+  startImportPrivateKey: (): void => {},
   wallets: [],
   refreshWallets: async (): Promise<void> => {},
 })

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -30,6 +30,7 @@ export type MigrationEntry =
   | 'create-vault'
   | 'recover-seed-input'
   | 'import-vault'
+  | 'import-private-key'
 
 export default function AppNavigator(): React.ReactElement | null {
   const [wallets, setWallets] = useState<LocalWallet[] | null>(null)
@@ -127,6 +128,12 @@ export default function AppNavigator(): React.ReactElement | null {
     setRootRoute('Migration')
   }, [])
 
+  const startImportPrivateKey = useCallback(() => {
+    preMigrationRootRef.current = rootRouteRef.current
+    setMigrationEntry('import-private-key')
+    setRootRoute('Migration')
+  }, [])
+
   const goToAuth = useCallback(() => {
     setMigrationEntry('default')
     setRootRoute('Auth')
@@ -173,6 +180,7 @@ export default function AppNavigator(): React.ReactElement | null {
       startCreateVault,
       startSeedRecoveryInput,
       startImportVault,
+      startImportPrivateKey,
       wallets,
       refreshWallets,
     }),
@@ -184,6 +192,7 @@ export default function AppNavigator(): React.ReactElement | null {
       startCreateVault,
       startSeedRecoveryInput,
       startImportVault,
+      startImportPrivateKey,
       wallets,
       refreshWallets,
     ]

--- a/src/screens/WalletList.tsx
+++ b/src/screens/WalletList.tsx
@@ -46,6 +46,7 @@ export default function WalletList(): React.ReactElement {
     startCreateVault,
     startSeedRecoveryInput,
     startImportVault,
+    startImportPrivateKey,
   } = useWalletNav()
 
   // Refresh the list of wallets on focus so returning from the
@@ -265,6 +266,14 @@ export default function WalletList(): React.ReactElement {
           inMigrationNav
             ? (): void => migrationNav.navigate('ImportVault')
             : startImportVault
+        }
+        onImportPrivateKey={
+          inMigrationNav
+            ? (): void =>
+                migrationNav.navigate('VaultName', {
+                  mode: 'import-private-key',
+                })
+            : startImportPrivateKey
         }
       />
     </View>

--- a/src/screens/auth/AuthMenu.tsx
+++ b/src/screens/auth/AuthMenu.tsx
@@ -22,7 +22,6 @@ const AuthMenu = ({
     goToMigration,
     startCreateVault,
     startImportVault,
-    startImportPrivateKey,
     startSeedRecoveryInput,
   } = useWalletNav()
   const insets = useSafeAreaInsets()
@@ -83,16 +82,6 @@ const AuthMenu = ({
           >
             <Text style={styles.secondaryButtonText}>
               Import Fast Vault
-            </Text>
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            testID="auth-import-private-key"
-            style={styles.secondaryButton}
-            onPress={startImportPrivateKey}
-          >
-            <Text style={styles.secondaryButtonText}>
-              Import Private Key
             </Text>
           </TouchableOpacity>
 

--- a/src/screens/auth/AuthMenu.tsx
+++ b/src/screens/auth/AuthMenu.tsx
@@ -22,6 +22,7 @@ const AuthMenu = ({
     goToMigration,
     startCreateVault,
     startImportVault,
+    startImportPrivateKey,
     startSeedRecoveryInput,
   } = useWalletNav()
   const insets = useSafeAreaInsets()
@@ -82,6 +83,16 @@ const AuthMenu = ({
           >
             <Text style={styles.secondaryButtonText}>
               Import Fast Vault
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            testID="auth-import-private-key"
+            style={styles.secondaryButton}
+            onPress={startImportPrivateKey}
+          >
+            <Text style={styles.secondaryButtonText}>
+              Import Private Key
             </Text>
           </TouchableOpacity>
 

--- a/src/screens/migration/ImportPrivateKey.tsx
+++ b/src/screens/migration/ImportPrivateKey.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { View, StyleSheet, TextInput } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useNavigation, useRoute } from '@react-navigation/native'
@@ -15,31 +15,35 @@ import StepProgressBar from 'components/migration/StepProgressBar'
 import MigrationToolbar from 'components/migration/MigrationToolbar'
 import { formStyles } from 'components/migration/migrationStyles'
 import { MIGRATION } from 'consts/migration'
-import { isValidEmail } from 'utils/isValidEmail'
 import type { MigrationStackParams } from 'navigation/MigrationNavigator'
+import {
+  validatePrivateKey,
+  type ValidatedPrivateKey,
+} from 'services/privateKeyImport'
 
-type Nav = StackNavigationProp<MigrationStackParams, 'VaultEmail'>
-type Route = RouteProp<MigrationStackParams, 'VaultEmail'>
+type Nav = StackNavigationProp<
+  MigrationStackParams,
+  'ImportPrivateKey'
+>
+type Route = RouteProp<MigrationStackParams, 'ImportPrivateKey'>
 
-export default function VaultEmail(): React.ReactElement {
+export default function ImportPrivateKey(): React.ReactElement {
   const navigation = useNavigation<Nav>()
   const route = useRoute<Route>()
-  const {
-    walletName,
-    mode,
-    wallets,
-    email: prefillEmail,
-    privateKeyHex,
-  } = route.params
-
-  const [email, setEmail] = useState(prefillEmail ?? '')
-
-  const valid = isValidEmail(email)
-  const showError = email.length > 0 && !valid
-
-  const stepBarCurrentStep = mode === 'create' ? 2 : 1
-
+  const { walletName } = route.params
   const insets = useSafeAreaInsets()
+  const [value, setValue] = useState('')
+
+  const validated = useMemo<ValidatedPrivateKey | null>(() => {
+    if (!value.trim()) return null
+    try {
+      return validatePrivateKey(value)
+    } catch {
+      return null
+    }
+  }, [value])
+
+  const showError = value.trim().length > 0 && !validated
 
   return (
     <View style={formStyles.container}>
@@ -48,7 +52,7 @@ export default function VaultEmail(): React.ReactElement {
           <MigrationToolbar onBack={() => navigation.goBack()} />
         </View>
 
-        <StepProgressBar currentStep={stepBarCurrentStep} />
+        <StepProgressBar currentStep={2} />
 
         <Animated.View
           entering={FadeInRight.duration(250)}
@@ -56,32 +60,48 @@ export default function VaultEmail(): React.ReactElement {
           style={formStyles.content}
         >
           <Text style={formStyles.title} fontType="brockmann-medium">
-            Enter your email
+            Import private key
           </Text>
-
           <Text style={formStyles.subtitle} fontType="brockmann">
-            This will only be used once to send your backup file.
-            Vultisig doesn&apos;t store any data.
+            This imports a Terra private key only. Use seed phrase
+            recovery for a multichain wallet.
           </Text>
 
           <TextInput
-            testID="vault-email-input"
+            testID="private-key-input"
             style={[styles.input, showError && styles.inputError]}
-            value={email}
-            onChangeText={setEmail}
-            placeholder="you@example.com"
-            placeholderTextColor={MIGRATION.textTertiary}
-            keyboardType="email-address"
+            value={value}
+            onChangeText={setValue}
+            placeholder="Paste private key"
+            placeholderTextColor={MIGRATION.textInputPlaceholder}
             autoCapitalize="none"
             autoCorrect={false}
-            autoComplete="email"
+            secureTextEntry
           />
 
-          {showError && (
+          {showError ? (
             <Text style={styles.errorText} fontType="brockmann">
-              Incorrect e-mail, please check
+              Enter a valid 64-character hex private key.
             </Text>
-          )}
+          ) : null}
+
+          {validated ? (
+            <View style={styles.preview}>
+              <Text
+                fontType="brockmann-medium"
+                style={styles.previewLabel}
+              >
+                Terra address
+              </Text>
+              <Text
+                fontType="brockmann"
+                style={styles.previewAddress}
+                numberOfLines={2}
+              >
+                {validated.terraAddress}
+              </Text>
+            </View>
+          ) : null}
         </Animated.View>
 
         <View
@@ -91,18 +111,17 @@ export default function VaultEmail(): React.ReactElement {
           ]}
         >
           <Button
-            testID="vault-email-next"
-            title="Next"
+            testID="private-key-next"
+            title="Continue"
             theme="ctaBlue"
             titleFontType="brockmann-medium"
-            disabled={!valid}
+            disabled={!validated}
             onPress={() => {
-              navigation.navigate('VaultPassword', {
+              if (!validated) return
+              navigation.navigate('VaultEmail', {
                 walletName,
-                mode,
-                wallets,
-                email,
-                privateKeyHex,
+                mode: 'import-private-key',
+                privateKeyHex: validated.privateKeyHex,
               })
             }}
             containerStyle={formStyles.ctaButton}
@@ -132,5 +151,23 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: MIGRATION.errorRed,
     marginTop: 6,
+  },
+  preview: {
+    marginTop: 18,
+    padding: 16,
+    borderRadius: 12,
+    backgroundColor: MIGRATION.surface1,
+    borderWidth: 1,
+    borderColor: MIGRATION.strokeInput,
+  },
+  previewLabel: {
+    fontSize: 12,
+    color: MIGRATION.textTertiary,
+    marginBottom: 8,
+  },
+  previewAddress: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: MIGRATION.textPrimary,
   },
 })

--- a/src/screens/migration/KeygenProgress.tsx
+++ b/src/screens/migration/KeygenProgress.tsx
@@ -62,6 +62,7 @@ export default function KeygenProgress(): React.ReactElement {
     email,
     password,
     mode,
+    privateKeyHex,
   } = route.params
 
   const [progress, setProgress] = useState(0)
@@ -206,6 +207,18 @@ export default function KeygenProgress(): React.ReactElement {
           onProgress: updateProgress,
           signal: controller.signal,
         })
+      } else if (mode === 'import-private-key') {
+        if (!privateKeyHex) {
+          throw new Error('No private key available for import')
+        }
+        result = await importKeyToFastVault({
+          name: walletName,
+          email,
+          password,
+          privateKeyHex,
+          onProgress: updateProgress,
+          signal: controller.signal,
+        })
       } else {
         const authEntry = await getAuthDataValue(walletName)
         if (!authEntry || authEntry.ledger) {
@@ -256,6 +269,7 @@ export default function KeygenProgress(): React.ReactElement {
     walletIndex,
     updateProgress,
     recoverSeed,
+    privateKeyHex,
   ])
 
   useEffect(() => {

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -56,6 +56,9 @@ export default function MigrationHome(): React.ReactElement {
   const startImportVaultFromHere = (): void => {
     navigation.navigate('ImportVault')
   }
+  const startImportPrivateKeyFromHere = (): void => {
+    navigation.navigate('VaultName', { mode: 'import-private-key' })
+  }
   const startCreateVaultFromHere = (): void => {
     navigation.navigate('VaultName', { mode: 'create' })
   }
@@ -251,6 +254,7 @@ export default function MigrationHome(): React.ReactElement {
         onCreate={startCreateVaultFromHere}
         onRecover={startSeedRecoveryFromHere}
         onImport={startImportVaultFromHere}
+        onImportPrivateKey={startImportPrivateKeyFromHere}
         // MigrationHome's "Import wallet" entry is for users who already
         // have a wallet — Create would just be a misroute. The shared sheet
         // still defaults to showing it for the WalletList entry.

--- a/src/screens/migration/VaultName.tsx
+++ b/src/screens/migration/VaultName.tsx
@@ -99,10 +99,17 @@ export default function VaultName(): React.ReactElement {
             disabled={name.trim().length === 0}
             titleFontType="brockmann-medium"
             onPress={() => {
-              navigation.navigate('VaultEmail', {
-                walletName: name.trim(),
-                mode,
-              })
+              const walletName = name.trim()
+              if (mode === 'import-private-key') {
+                navigation.navigate('ImportPrivateKey', {
+                  walletName,
+                })
+              } else {
+                navigation.navigate('VaultEmail', {
+                  walletName,
+                  mode,
+                })
+              }
             }}
             containerStyle={formStyles.ctaButton}
           />

--- a/src/screens/migration/VaultPassword.tsx
+++ b/src/screens/migration/VaultPassword.tsx
@@ -23,7 +23,8 @@ type Route = RouteProp<MigrationStackParams, 'VaultPassword'>
 export default function VaultPassword(): React.ReactElement {
   const navigation = useNavigation<Nav>()
   const route = useRoute<Route>()
-  const { walletName, mode, wallets, email } = route.params
+  const { walletName, mode, wallets, email, privateKeyHex } =
+    route.params
 
   const [password, setPassword] = useState('')
   const [confirm, setConfirm] = useState('')
@@ -132,6 +133,7 @@ export default function VaultPassword(): React.ReactElement {
                 wallets,
                 email,
                 password,
+                privateKeyHex,
               })
             }}
             containerStyle={formStyles.ctaButton}

--- a/src/services/migrateToVault.ts
+++ b/src/services/migrateToVault.ts
@@ -254,12 +254,15 @@ export async function storeFastVault(
           encryptedKey: '',
           password: '',
           ledger: false,
-          terraOnly: !isCreatedVault && !isSeedImportVault,
+          ...(!isCreatedVault && !isSeedImportVault
+            ? { terraOnly: true }
+            : {}),
         },
       },
     })
   } else if (!existing) {
-    // New vault creation: register in authData so getWallets() can find it
+    // New vault creation/import: register in authData so getWallets() can find it.
+    // Single-key imports are Terra-only, matching migrated legacy private-key vaults.
     await upsertAuthData({
       authData: {
         [walletName]: {
@@ -267,6 +270,9 @@ export async function storeFastVault(
           encryptedKey: '',
           password: '',
           ledger: false,
+          ...(!isCreatedVault && !isSeedImportVault
+            ? { terraOnly: true }
+            : {}),
         },
       },
     })

--- a/src/services/privateKeyImport.ts
+++ b/src/services/privateKeyImport.ts
@@ -1,0 +1,37 @@
+import { RawKey } from '@terra-money/terra.js'
+
+import { derivePublicKeyHex } from './vaultProto'
+
+export type ValidatedPrivateKey = {
+  privateKeyHex: string
+  publicKeyHex: string
+  terraAddress: string
+}
+
+export function normalizePrivateKey(input: string): string {
+  return input.trim().replace(/^0x/i, '').replace(/\s+/g, '')
+}
+
+export function validatePrivateKey(
+  input: string
+): ValidatedPrivateKey {
+  const privateKeyHex = normalizePrivateKey(input)
+
+  if (!/^[0-9a-fA-F]{64}$/.test(privateKeyHex)) {
+    throw new Error('Private key must be 64 hexadecimal characters.')
+  }
+
+  try {
+    const privateKeyBytes = Buffer.from(privateKeyHex, 'hex')
+    const rawKey = new RawKey(privateKeyBytes)
+    const publicKeyHex = derivePublicKeyHex(privateKeyHex)
+
+    return {
+      privateKeyHex: privateKeyHex.toLowerCase(),
+      publicKeyHex,
+      terraAddress: rawKey.accAddress,
+    }
+  } catch {
+    throw new Error('Invalid secp256k1 private key.')
+  }
+}


### PR DESCRIPTION
## Description

@NeOMakinG this restores the private key import flow after #99, but keeps it on the production migration/add-wallet entry points instead of the bypass auth screen.

- adds `ImportPrivateKey` under the migration navigator and add-wallet sheet
- imports a Terra private key as a Terra-only `KEYIMPORT` vault, matching migrated legacy private-key vaults
- marks new single-key imports with `terraOnly: true` in authData so wallet filtering treats them the same as migrated Terra-only vaults
- keeps seed phrase and created Fast Vault paths unchanged as multichain Vultisig-compatible vaults

## Proof

The vault storage path now matches the migrated private-key shape:

- `libType: KEYIMPORT`
- ECDSA public key set from the imported Terra private key
- no EdDSA public key
- no chain code
- `chainPublicKeys` contains Terra only
- authData gets `terraOnly: true`

Existing seed phrase and Fast Vault creation tests still assert the Vultisig-compatible multichain derivation shape separately.

## Screenshot

Production entry point on a fresh install:

![Private key import entry point](https://files.catbox.moe/mqiam0.png)

## Verification

- `npm test -- --runInBand __tests__/wallet/private-key-import.test.ts __tests__/wallet/vault-store.test.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint:check`
- `git diff --check origin/main...HEAD`
