### PR TITLE
fix(vault-kind): KEYIMPORT vaults with server signer should classify as 'fast'

### DIFF
--- a/__tests__/wallet/vault-kind.test.ts
+++ b/__tests__/wallet/vault-kind.test.ts
@@ -79,4 +79,19 @@ describe('getVaultKind', () => {
     await storeVault('SoloVault', ['OnlyDevice'], 'OnlyDevice')
     expect(await getVaultKind('SoloVault')).toBe('multi-share')
   })
+
+  it("returns 'fast' for a KEYIMPORT vault with a server signer (post-#93 seed-import shape)", async () => {
+    // PR #93 stores seed-imported vaults as libType=KEYIMPORT (because that
+    // is what setupKeyImport registers them as on the server). The signer
+    // set is still (device, Server-XXX) — i.e. a fast vault. A previous
+    // version of getVaultKind early-returned 'multi-share' on any non-DKLS
+    // libType, which mis-classified these vaults; this test pins the fix.
+    await storeVault(
+      'KeyImportFastVault',
+      ['sdk-deadbe', 'Server-12345'],
+      'sdk-deadbe',
+      LibType.KEYIMPORT,
+    )
+    expect(await getVaultKind('KeyImportFastVault')).toBe('fast')
+  })
 })

--- a/src/services/migrateToVault.ts
+++ b/src/services/migrateToVault.ts
@@ -292,7 +292,18 @@ export async function getVaultKind(
   if (!stored) return 'none'
   try {
     const decoded = fromBinary(VaultSchema, base64.decode(stored))
-    if (decoded.libType !== LibType.DKLS) return 'multi-share'
+    // "Fast vault" is a structural property of the signers, not the
+    // crypto protocol: a 2-of-2 vault where one party is VultiServer and
+    // the other is the user's device. This holds regardless of whether
+    // the keyshares are DKLS-keygen'd or KEY-IMPORTed — both protocols
+    // produce fast vaults when the signer set is (device, Server-XXX).
+    //
+    // We previously gated on `libType === DKLS`, which incorrectly
+    // classified post-#93 seed-imported fast vaults (stored as KEYIMPORT
+    // because that's what `setupKeyImport` registers them as on the
+    // server) as multi-share, surfacing the wrong "Vault" chip in
+    // WalletList instead of "Fast Vault".
+    //
     // localPartyId is server-side → not a fast vault from user perspective
     if (decoded.localPartyId?.toLowerCase().startsWith('server-')) {
       return 'multi-share'


### PR DESCRIPTION
## Summary

Post-#93, seed-imported vaults are stored with `libType: KEYIMPORT` (because that's what `setupKeyImport` registers them as on the server). The `getVaultKind` discriminator from #91 had an early-return `if (libType !== DKLS) return 'multi-share'` written before seed-imports adopted KEYIMPORT, so those vaults now show as **"Vault"** in `WalletList` instead of **"Fast Vault"**.

App isn't deployed yet, so this isn't actively misleading users in production — but it's wrong against the canonical iOS/vultiagent-app classification (which is "fast = device + VultiServer signers, regardless of protocol") and would surface the wrong chip on the next deployed build.

## Diagnosis

A "fast vault" is a structural property of the **signer set** (`device + VultiServer`), not of the crypto protocol used for the keyshares. Both DKLS-keygen and KEYIMPORT-protocol vaults can be either fast or multi-share. The libType gate was a false proxy that worked pre-#93 only because seed-imports happened to be DKLS-shaped at that point.

## Change

Drop the libType check from `getVaultKind`. Classify purely on signers:
- localPartyId starts with `server-` → `'multi-share'` (server-side instance shouldn't self-classify as fast)
- otherwise, any `server-`-prefixed signer in the set → `'fast'`
- otherwise → `'multi-share'`

This matches iOS `Vault.swift:172` and vultiagent-app `vaultUtils.ts:6`.

## Test plan

- [x] New test case in `__tests__/wallet/vault-kind.test.ts` pinning the post-#93 seed-import shape (KEYIMPORT + `sdk-`/`Server-` signers) to `'fast'` — passes.
- [x] All existing `getVaultKind` tests still pass (DKLS fast vault, multi-device, server-side instance, solo).
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint:check` clean
- [x] `npx jest` (full suite) — passing

## Out of scope

- Other consumers of `isFastVault` / `getVaultKind` (e.g. `ExportPrivateKey.tsx`'s `!isFastVault` branch) — those benefit from this fix automatically since `isFastVault` delegates to `getVaultKind`.