### PR TITLE
fix(migration-home): restore StorageCipher18 dev seeder button (lost in #101 merge)

### DIFF
--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import {
+  Platform,
   View,
   StyleSheet,
   TouchableOpacity,
@@ -243,6 +244,20 @@ export default function MigrationHome(): React.ReactElement {
                   Seed Corrupt Data (dev)
                 </Text>
               </TouchableOpacity>
+              {DevFlags.SeedLegacyDataAndroidV1 &&
+                Platform.OS === 'android' && (
+                  <TouchableOpacity
+                    testID="dev-seed-legacy-android-v1"
+                    style={styles.devButton}
+                    onPress={() =>
+                      navigation.navigate('SeedLegacyDataAndroidV1')
+                    }
+                  >
+                    <Text style={styles.devButtonText}>
+                      Seed StorageCipher18 (Android, dev)
+                    </Text>
+                  </TouchableOpacity>
+                )}
             </View>
           )}
         </View>


### PR DESCRIPTION
## Summary

PR #101 originally added the **"Seed StorageCipher18 (Android, dev)"** button to `MigrationHome.tsx` in commit `5387fda`, but the squash-merge into main lost that addition — only the parallel `AuthMenu.tsx` button survived.

Verified by diffing `5387fda:src/screens/migration/MigrationHome.tsx` against `HEAD:src/screens/migration/MigrationHome.tsx` after PR #101 was merged: the entire StorageCipher18 button block is gone in HEAD, including the `Platform` import. CI green at the time (the loss happened at merge resolution, not at push).

## User-visible impact

Users entering the migration flow from the default welcome screen ("Your seed phrase becomes a Fast Vault") see only **Seed Legacy Data (dev)** and **Seed Corrupt Data (dev)** — no way to seed a StorageCipher18 RSA+AES blob without bypassing into AuthMenu via the test-only `BYPASS_AUTH_FOR_TESTING` env flag.

This makes PR #101's StorageCipher18 recovery untestable from the production-like dev path.

## Change

Re-apply `5387fda`'s MigrationHome change verbatim. One-line `Platform` import added, plus the same button block with the `Platform.OS === 'android'` guard since the StorageCipher18 format is Android-only (the iOS Swift module's `seedLegacyTestDataStorageCipher18` returns a no-op).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint:check` clean
- [x] `npx jest` — 164/164 pass
- [x] Manual: Pixel_8 emulator with `EXPO_PUBLIC_SHOW_DEV_FEATURES=true`, MigrationHome screen now shows three dev-seed buttons including "Seed StorageCipher18 (Android, dev)"