### PR TITLE
chore(release): bump version 5.0.7 → 5.1.0

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Station",
     "slug": "vultisig",
-    "version": "5.0.7",
+    "version": "5.1.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -42,7 +42,7 @@
         "backgroundColor": "#1f42b4"
       },
       "package": "money.terra.station",
-      "versionCode": 50000001,
+      "versionCode": 50100001,
 
       "permissions": [
         "android.permission.CAMERA",


### PR DESCRIPTION
## Summary

Minor version bump for the migration / keygen / recovery work shipped since 5.0.7.

| PR | What it shipped |
|---|---|
| #97 | Seed-import keygen reliability — `setupMessageId` relay-channel fix |
| #100 | Terra-only private-key import flow |
| #101 | StorageCipher18 RSA+AES recovery for pre-2021-07-22 Android cohort + V2 retry semantics + dev hardening |
| #102 | KEYIMPORT vaults correctly classified as "Fast Vault" |

## Cross-app verification (already done as part of each PR)

| Flow | Source key | Vultisig-side address | Canonical match |
|---|---|---|---|
| Seed-recover (#97) | `abandon × 12` | `terra1amdttz...` | ✅ |
| Legacy AD migrate (existing) | `0x0...0001` | `terra1w508d6...` | ✅ |
| Private-key import (#100) | abandon m/44'/330'/0'/0/0 child | `terra1amdttz...` | ✅ |
| StorageCipher18 migrate (#101) | `0x0...0001` via RSA+AES blob | `terra1w508d6...` | ✅ |

## Files changed

- `app.json` — `expo.version` 5.0.7 → 5.1.0; `android.versionCode` 50000001 → 50100001

`android/app/build.gradle` is gitignored (regenerated by `expo prebuild` from `app.json`). iOS `buildNumber` stays at 1 per existing convention. EAS-driven builds pick the new version up from `app.json`.

## Why minor, not patch

#101 added a brand-new recovery path (StorageCipher18 RSA+AES), and #100 added a brand-new top-level import flow (private key). Both are user-facing additions, not bug fixes — minor bump is the right semver call.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint:check` clean
- [x] `npx jest` — 164/164 pass