### PR TITLE
fix(banner): hide Terra-Station-fine sentence on iOS

### DIFF
--- a/src/components/DerivationWarningBanner.tsx
+++ b/src/components/DerivationWarningBanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { View, StyleSheet } from 'react-native'
+import { Platform, View, StyleSheet } from 'react-native'
 import type { StyleProp, ViewStyle } from 'react-native'
 import Svg, { Path } from 'react-native-svg'
 
@@ -45,8 +45,10 @@ export default function DerivationWarningBanner({
       <Text fontType="brockmann" style={styles.body}>
         If you imported a seed phrase or created a new vault here
         before seeing this warning, re-create or re-import it to
-        ensure correct addresses on Vultisig. Vaults migrated from
-        your original Terra Station wallet are fine.
+        ensure correct addresses on Vultisig.
+        {Platform.OS === 'android'
+          ? ' Vaults migrated from your original Terra Station wallet are fine.'
+          : ''}
       </Text>
     </View>
   )


### PR DESCRIPTION
## Summary

Hide the *"Vaults migrated from your original Terra Station wallet are fine."* sentence in `DerivationWarningBanner` on iOS — surfaced as confusing user feedback (the sentence has no concrete referent on iOS).

The sentence is Android-cohort-specific. The OLD Terra Station Wallet on iOS was effectively limited to the iOS Keychain `_secure_storage_service` path that the new station-mobile already migrates correctly — there's no equivalent of the Android StorageCipher18 / legacy AD-decrypt recovery on iOS (per the storage-paths spike in `.spikes/old-station-storage-formats-2026-05-08.md`).

Android users keep the sentence verbatim; iOS users just see the actionable instruction without the orphan reassurance.

## Change

`src/components/DerivationWarningBanner.tsx`:
- import `Platform` from `react-native`
- gate the trailing sentence on `Platform.OS === 'android'`

## OTA-readiness

JS-only change. **Does NOT touch native code or `app.json` runtime policy** — keeps `runtimeVersion.policy: "fingerprint"` intact so the OTA published from this commit will tag with the same fingerprint hash as the deployed iOS 5.1.0 binary, and reach existing 5.1.0 testers immediately.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint:check` clean
- [x] `npx jest` — 164/164 pass