### PR TITLE
feat(migration): legacy Station Wallet (web) redirect button

### DIFF
--- a/__mocks__/react-native.js
+++ b/__mocks__/react-native.js
@@ -1,6 +1,6 @@
 // Minimal React Native mock for unit tests
 module.exports = {
   Platform: { OS: 'ios', select: (obj) => obj.ios },
-  Alert: { alert: () => {} },
-  Linking: { openURL: () => {} },
+  Alert: { alert: jest.fn() },
+  Linking: { openURL: jest.fn().mockResolvedValue(undefined) },
 }

--- a/__tests__/migration/open-legacy-station.test.ts
+++ b/__tests__/migration/open-legacy-station.test.ts
@@ -1,0 +1,45 @@
+import { Alert, Linking } from 'react-native'
+import { openLegacyStation, LEGACY_STATION_URL } from 'utils/openLegacyStation'
+
+const mockAlert = Alert.alert as jest.Mock
+const mockOpenURL = Linking.openURL as jest.Mock
+
+beforeEach(() => {
+  mockAlert.mockClear()
+  mockOpenURL.mockClear()
+})
+
+describe('openLegacyStation', () => {
+  it('opens a confirmation Alert before navigating', () => {
+    openLegacyStation()
+
+    expect(mockAlert).toHaveBeenCalledTimes(1)
+    const [title, message] = mockAlert.mock.calls[0]
+    expect(title).toBe('Open legacy Station')
+    expect(message).toContain('no longer maintained')
+  })
+
+  it('calls Linking.openURL with the legacy Station URL when user confirms', () => {
+    openLegacyStation()
+
+    // Simulate user tapping "Open" — second button in the Alert buttons array
+    const [, , buttons] = mockAlert.mock.calls[0]
+    const openButton = buttons.find((b: { text: string }) => b.text === 'Open')
+    expect(openButton).toBeDefined()
+    openButton!.onPress()
+
+    expect(mockOpenURL).toHaveBeenCalledWith(LEGACY_STATION_URL)
+    expect(mockOpenURL).toHaveBeenCalledWith('https://mobile.station.terra.money/')
+  })
+
+  it('does not call Linking.openURL when user cancels', () => {
+    openLegacyStation()
+
+    // Simulate user tapping "Cancel"
+    const [, , buttons] = mockAlert.mock.calls[0]
+    const cancelButton = buttons.find((b: { text: string }) => b.text === 'Cancel')
+    expect(cancelButton).toBeDefined()
+    // Cancel button has no onPress — just verify Linking was not called
+    expect(mockOpenURL).not.toHaveBeenCalled()
+  })
+})

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -26,6 +26,7 @@ import {
   MigrationWallet,
 } from 'services/migrateToVault'
 import { getWallets } from 'utils/wallet'
+import { openLegacyStation } from 'utils/openLegacyStation'
 import { useWalletNav } from 'navigation/hooks'
 import type { MigrationStackParams } from 'navigation/MigrationNavigator'
 import AddWalletSheet from 'components/AddWalletSheet'
@@ -219,6 +220,19 @@ export default function MigrationHome(): React.ReactElement {
                 style={styles.linkText}
               >
                 Learn more about Vault security
+              </Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={styles.linkButton}
+              onPress={openLegacyStation}
+              testID="open-legacy-station"
+            >
+              <Text
+                fontType="brockmann-medium"
+                style={styles.linkText}
+              >
+                Open legacy Station (web)
               </Text>
             </TouchableOpacity>
           </Animated.View>

--- a/src/utils/openLegacyStation.ts
+++ b/src/utils/openLegacyStation.ts
@@ -1,0 +1,28 @@
+import { Alert, Linking } from 'react-native'
+
+export const LEGACY_STATION_URL = 'https://mobile.station.terra.money/'
+
+/**
+ * Opens the legacy Station PWA in the user's default browser.
+ * Shows a confirmation dialog first so users understand the app is unmaintained.
+ */
+export function openLegacyStation(): void {
+  Alert.alert(
+    'Open legacy Station',
+    'This opens the legacy Station web app in your browser. The legacy app is no longer maintained — use it at your own risk.',
+    [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Open',
+        onPress: () => {
+          Linking.openURL(LEGACY_STATION_URL).catch(() => {
+            Alert.alert(
+              'Could not open URL',
+              'Please visit mobile.station.terra.money manually.'
+            )
+          })
+        },
+      },
+    ]
+  )
+}


### PR DESCRIPTION
## Summary

Adds an "Open legacy Station (web)" link button to the migration screen (`MigrationHome`). Tapping it shows an Alert confirmation, then opens `https://mobile.station.terra.money/` in the user's default browser via `Linking.openURL`. This is a JS-only, OTA-deliverable escape hatch for users whose wallets are not being recovered by the current Path A migration logic — they can log into the legacy SPA, export their seed, and re-import in Station Mobile 5.x.

## Why now

Station Mobile 2.x (post-2022-03-31 cohort) stored most user wallets in WebView `localStorage["keys"]` at `mobile.station.terra.money`, not in the iOS Keychain. The current 5.x migration reads only iOS Keychain (Path A). Until the native Path B extraction lands — which requires a native module to bridge into the WKWebView data store — affected users have no automated path to recover their wallets in-app.

The wallet-storage spike (gist: https://gist.github.com/NeOMakinG/e55b3106e82f68121134b756380caec1) documents this cohort and lays out the full extraction plan. This redirect is the lowest-risk stopgap: zero new native dependencies, fully OTA-deliverable, and gives affected users a clear action they can take today. The button only appears on the migration screen so it is not surfaced to users who have already completed migration.

## Implementation

- `src/utils/openLegacyStation.ts` — exports `LEGACY_STATION_URL` constant and `openLegacyStation()` handler. The handler calls `Alert.alert` with a confirmation step before invoking `Linking.openURL` so that taps are intentional (no accidental browser launches).
- `src/screens/migration/MigrationHome.tsx` — imports the utility and adds a `TouchableOpacity` link button after the "Learn more about Vault security" row. Styled to match the existing secondary link pattern on the screen.
- No new native dependencies. No changes to navigation structure or vault storage logic.

## Test plan

- [x] `yarn test __tests__/migration/open-legacy-station.test.ts` — all 3 unit tests pass (alert shown, URL opened on confirm, URL not opened on cancel)
- [x] Full suite: 167/167 pass
- [ ] Manual: tap the button on iOS sim → Alert appears → confirm → Safari opens → SPA loads at `https://mobile.station.terra.money/` (note: SPA may CF-rate-limit on some networks; VPN bypass works)
- [ ] Manual: same flow on Android emulator
- [ ] Manual: tap cancel in Alert → browser does NOT open

## Screenshots

_To be added by reviewer after manual testing on device/simulator._

## Out of scope

Automatic extraction of WebView `localStorage` contents (the native module track described in the gist plan). That is a separate, larger PR requiring a native module and full QA of the extraction pipeline. This PR is purely the redirect escape hatch.
