### PR TITLE
chore(migration-home): drop "(web)" suffix from legacy Station link

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -25,7 +25,7 @@ export const DevFlags = {
 /**
  * Production-flippable flags. Default off; flipped via Expo env (OTA-deployable).
  *
- * - `OpenLegacyStationWebView`: exposes the "Open legacy Station (web)" link on
+ * - `OpenLegacyStationWebView`: exposes the "Open legacy Station" link on
  *   MigrationHome. Disabled by default — users find their legacy wallets via the
  *   hidden discovery WebView instead, which surfaces them in the regular
  *   wallets-found list. The link is kept available for QA/support escalation.

--- a/src/screens/migration/MigrationHome.tsx
+++ b/src/screens/migration/MigrationHome.tsx
@@ -241,7 +241,7 @@ export default function MigrationHome(): React.ReactElement {
                   fontType="brockmann-medium"
                   style={styles.linkText}
                 >
-                  Open legacy Station (web)
+                  Open legacy Station
                 </Text>
               </TouchableOpacity>
             )}


### PR DESCRIPTION
## What

Renames the dev-gated MigrationHome link from **"Open legacy Station (web)"** → **"Open legacy Station"**. Comment in `src/config/env.ts` updated to match.

The "(web)" qualifier was a debugging hint left over from the earlier escape-hatch PR (#106) — users don't need to think about transport. Everywhere else in the migration flow we refer to it as "legacy Station" already; this just removes the inconsistency.

## Why this is safe

- 2-line change, copy only — no behavior change.
- The link remains gated behind \`FeatureFlags.OpenLegacyStationWebView\` (default off in production builds). No new surface area.
- testID \`open-legacy-station\` is unchanged, so any existing QA selectors continue to match.

## Test plan

- [ ] iOS build with \`EXPO_PUBLIC_OPEN_LEGACY_STATION_WEBVIEW=true\`, confirm MigrationHome shows "Open legacy Station" (no parenthetical).
- [ ] Default production build (env var unset), confirm the link is still hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)