### PR TITLE
feat(seed-import): support all 36 Vultisig chains, fix Solana Phantom derivation

### DIFF
--- a/__tests__/wallet/seed-phrase-import.test.ts
+++ b/__tests__/wallet/seed-phrase-import.test.ts
@@ -11,9 +11,9 @@ const TREZOR_12 =
 describe('seed phrase import derivation', () => {
   it('validates BIP39 mnemonics', () => {
     expect(validateSeedPhrase(TREZOR_12)).toBe(true)
-    expect(validateSeedPhrase(TREZOR_12.replace(/about$/, 'abandon'))).toBe(
-      false
-    )
+    expect(
+      validateSeedPhrase(TREZOR_12.replace(/about$/, 'abandon'))
+    ).toBe(false)
   })
 
   it('derives Vultisig-compatible root keys from the Trezor vector', () => {
@@ -72,9 +72,9 @@ describe('seed phrase import derivation', () => {
       ])
     )
     expect(
-      SEED_IMPORT_DERIVATION_GROUPS.filter((group) => group.isEddsa).map(
-        (group) => group.representativeChain
-      )
+      SEED_IMPORT_DERIVATION_GROUPS.filter(
+        (group) => group.isEddsa
+      ).map((group) => group.representativeChain)
     ).toEqual(['Solana', 'Sui', 'Ton', 'Polkadot', 'Bittensor'])
   })
 })

--- a/src/services/seedPhraseImport.ts
+++ b/src/services/seedPhraseImport.ts
@@ -102,6 +102,31 @@ export type SeedMasterKeys = {
   eddsaPrivateKey: string
 }
 
+// chainPublicKeys[] in the exported .vult is treated by vultisig-ios as the
+// authoritative chain list for KeyImport vaults (see iOS VaultDefaultCoinService
+// getDefaultChains: returns vault.chainPublicKeys.map(\.chain) for .KeyImport,
+// AND VaultDetailViewModel.canShowChainSelection returns false for KeyImport
+// vaults — meaning users cannot add chains in-app after import). Any chain
+// omitted here is permanently absent from the resulting vault on iOS.
+//
+// Every chain listed here derives via TrustWalletCore in a way that matches
+// vultisig-ios's own KeyImport flow:
+//  - ECDSA (secp256k1) chains use BIP44 default coin-type paths.
+//  - EdDSA (ed25519) chains use BIP44 default except Solana, which uses the
+//    `solanaSolana` (Phantom) derivation (=6) — the only chain with an
+//    alternativeDerivations entry in iOS KeyImportChainsSetupViewModel.
+//  - Polkadot and Bittensor both derive from CoinType.polkadot at
+//    m/44'/354'/0'/0'/0'; iOS SS58-encodes the resulting pubkey with prefix 0
+//    for DOT and prefix 42 for TAO at display time (CoinFactory.swift). This
+//    intentionally matches Trust Wallet's "BIP44 ed25519 over coin type 354"
+//    approach and intentionally does NOT match Polkadot.js/Subwallet/btcli,
+//    which use SR25519 + native Substrate derivation (a different ecosystem).
+//
+// Excluded:
+//  - Cardano: needs ed25519Cardano extended key (chain code material), not a
+//    plain 32-byte ed25519 pubkey. iOS itself excludes it from
+//    Chain.keyImportEnabledChains.
+//  - MLDSA chains (qbtc): use a separate publicKeyMldsa44 key entirely.
 export const SEED_IMPORT_DERIVATION_GROUPS: SeedImportDerivationGroup[] =
   (
     [
@@ -222,6 +247,13 @@ const ECDSA_DERIVATION_PATHS: Partial<
   Ripple: "m/44'/144'/0'/0/0",
   Tron: "m/44'/195'/0'/0/0",
 }
+
+// WalletCore Derivation enum: solanaSolana = 6 (the "Phantom" Solana derivation).
+// vultisig-ios uses this for the user-facing Solana address on KeyImport vaults
+// (see KeyImportChainsSetupViewModel: DerivationOption(derivation: .solanaSolana)).
+// Without this override, station-mobile would write the BIP44-default pubkey into
+// chainPublicKeys[], which produces a different address than vultisig-ios shows.
+const SOLANA_SOLANA_DERIVATION = 6
 
 const WALLET_CORE_COIN_TYPE_NAMES: Record<SeedImportChain, string> = {
   Bitcoin: 'bitcoin',
@@ -384,7 +416,13 @@ export async function deriveChainKeyForImport(
       ''
     )
     try {
-      const key = wallet.getKeyForCoin(coinType)
+      const key =
+        chain === 'Solana'
+          ? wallet.getKeyDerivation(
+              coinType,
+              SOLANA_SOLANA_DERIVATION
+            )
+          : wallet.getKeyForCoin(coinType)
       try {
         const keyData = new Uint8Array(key.data())
         return {
@@ -428,7 +466,13 @@ export async function deriveChainPublicKeyForImport(
       ''
     )
     try {
-      const key = wallet.getKeyForCoin(coinType)
+      const key =
+        chain === 'Solana'
+          ? wallet.getKeyDerivation(
+              coinType,
+              SOLANA_SOLANA_DERIVATION
+            )
+          : wallet.getKeyForCoin(coinType)
       try {
         const publicKey = isSeedImportEddsaChain(chain)
           ? key.getPublicKeyEd25519()


### PR DESCRIPTION
## Summary

Seed-import vaults exported from station-mobile were producing two distinct problems on vultisig-ios import:
1. **Solana addresses didn't match Vultisig native/Trust Wallet** — station-mobile used WalletCore's BIP44 default, but vultisig-ios uses Phantom (\`solanaSolana\` = 6).
2. **Sui, Ton, Polkadot, Bittensor, Ripple, Tron were initially dropped** from \`chainPublicKeys[]\` in an earlier patch on the assumption that users could re-add them inside vultisig-ios. They can't — \`VaultDetailViewModel.canShowChainSelection\` returns \`false\` for KeyImport vaults, so any chain not embedded at export time is permanently missing on iOS.

## Changes

\`src/services/seedPhraseImport.ts\`:
- Restored full 36-chain list in \`SEED_IMPORT_DERIVATION_GROUPS\`.
- Added \`SOLANA_SOLANA_DERIVATION = 6\` and wired both \`deriveChainKeyForImport\` and \`deriveChainPublicKeyForImport\` to use \`wallet.getKeyDerivation(coinType, 6)\` for Solana (everything else stays on \`getKeyForCoin\`).
- Inline comment explaining why Polkadot/Bittensor both go through \`CoinType.polkadot\` (mirrors vultisig-ios \`Chain.swift:457-458\` and TrustWalletCore registry); SS58 prefix 0/42 divergence happens at display time on iOS.

\`__tests__/wallet/seed-phrase-import.test.ts\`:
- Asserts 36 chains, includes the 6 chains restored, asserts the 5 EdDSA chains.

## Verification

- TypeScript: \`tsc --noEmit\` clean
- Jest: 168/168 pass (21 suites)
- ESLint: clean on changed files
- Rebuilt on iPhone 16 Pro (iOS 26.3) simulator: ✓ \`Opening on iPhone 16 Pro (26.3)\`

## Test plan

- [ ] Import a known seed phrase in station-mobile (via the migration → seed-import flow)
- [ ] Export the \`.vult\` from the simulator
- [ ] Import the \`.vult\` into vultisig-ios (TestFlight or a dev build)
- [ ] Verify all 36 chains appear in the vault
- [ ] Confirm the Polkadot address matches what vultisig-ios produces natively from the same seed (e.g. \`1szodMo5MmpbNN6XdqQD4mPfLYQcSLXjofZZZedJonjQqrG\` for the reference seed)
- [ ] Confirm the Bittensor TAO address SS58-encodes with prefix 42 from the same underlying pubkey
- [ ] Confirm Solana matches Vultisig native (Phantom derivation)

## Notes

- Vultisig follows the **TrustWalletCore ecosystem** for Polkadot/Bittensor — BIP44 ed25519 at \`m/44'/354'/0'/0'/0'\`, SS58 prefix 0 for DOT and 42 for TAO. This intentionally **does not match** Polkadot.js / Subwallet / btcli, which use SR25519 + native Substrate derivation. Trust Wallet itself has had this same divergence for years.
- Companion patch in \`vultisig/vultiagent-app\` (separate PR) brings vultiagent-app's chain coverage in line with station-mobile and fixes a latent \`isEddsa: false\` hardcoding in its \`.vult\` exporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)