### PR TITLE
chore(release): bump version to 5.1.2

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Station",
     "slug": "vultisig",
-    "version": "5.1.1",
+    "version": "5.1.2",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary

- Bump Expo app version from 5.1.1 to 5.1.2 in `app.json` ahead of the next iOS + Android EAS production builds.
- Captures the seed-import full-chain coverage + Solana Phantom derivation fix (#110) plus the 5.1.1 OTA that just shipped.
- Native build numbers (`ios.buildNumber`, `android.versionCode`) intentionally untouched: `eas.json` uses `appVersionSource: "remote"` and the `production` profile has `autoIncrement: true`, so EAS owns those values.

## Test plan
- [ ] Merge this PR
- [ ] Trigger `eas build --profile production --platform all` on `main`
- [ ] Confirm both iOS and Android builds report version 5.1.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)