### PR TITLE
chore(release): bump version to 5.1.3

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Station",
     "slug": "vultisig",
-    "version": "5.1.2",
+    "version": "5.1.3",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary

- Bump Expo app version from 5.1.2 to 5.1.3 in `app.json` ahead of the next iOS + Android EAS production builds.
- Carries the import-vault fix (#113): KeyImport `.vult` files are now accepted, and errors other than wrong password no longer surface as "Incorrect password".
- OTA for the same fix already shipped to existing 5.1.2 installs on the production channel ([iOS](https://expo.dev/accounts/vultisig/projects/vultisig/updates/718bb4f6-a165-439f-8278-74e0061ec506) / [Android](https://expo.dev/accounts/vultisig/projects/vultisig/updates/62138b89-2a0c-48e4-89aa-9cf4baa877ff)).
- Native build numbers (`ios.buildNumber`, `android.versionCode`) intentionally untouched: `eas.json` uses `appVersionSource: "remote"` and the `production` profile has `autoIncrement: true`.

## Test plan
- [ ] Merge this PR
- [ ] Trigger `eas build --profile production --platform all` on `main`
- [ ] Confirm both iOS and Android builds report version 5.1.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)