### PR TITLE
Remove .bak vault import support

### DIFF
--- a/__tests__/vault/import-file.test.ts
+++ b/__tests__/vault/import-file.test.ts
@@ -67,20 +67,14 @@ describe('importVaultBackup — .vult', () => {
   })
 })
 
-describe('importVaultBackup — .bak', () => {
-  it('decrypts and parses .bak files the same as .vult', () => {
-    const content = buildVaultContainer({
-      password: FIXTURE_PASSWORD,
-    })
-    const result = assertDecrypted(
+describe('importVaultBackup — unsupported extensions', () => {
+  it('rejects .bak files', () => {
+    expect(() =>
       importVaultBackup({
-        content,
+        content: '',
         fileName: 'test-vault.bak',
-        password: FIXTURE_PASSWORD,
       })
-    )
-    expect(result.vaultName).toBeTruthy()
-    expect(result.publicKeyEcdsa).toBeTruthy()
+    ).toThrow('Unsupported file type')
   })
 })
 

--- a/src/components/AddWalletSheet.tsx
+++ b/src/components/AddWalletSheet.tsx
@@ -257,7 +257,7 @@ export default function AddWalletSheet({
               fontType="brockmann-medium"
               style={styles.cardCaption}
             >
-              Supported file types: .bak & .vult
+              Supported file type: .vult
             </Text>
           </Pressable>
         </View>

--- a/src/hooks/useImportFlow.ts
+++ b/src/hooks/useImportFlow.ts
@@ -22,12 +22,12 @@ type SuccessResult = Extract<
   { needsPassword: false }
 >
 
-const DETOX_STAGED_FILES = ['detox-import.vult', 'detox-import.bak']
+const DETOX_STAGED_FILES = ['detox-import.vult']
 
 export type FileState = 'empty' | 'error' | 'success'
 
 const isVaultBackupFile = (name: string): boolean =>
-  /\.(vult|bak)$/i.test(name)
+  /\.vult$/i.test(name)
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- return type is inferred from complex hook state
 export function useImportFlow() {

--- a/src/screens/migration/ImportVault.tsx
+++ b/src/screens/migration/ImportVault.tsx
@@ -76,7 +76,7 @@ function ImportTooltip({
         </Text>
         <Text fontType="brockmann" style={styles.tooltipDescription}>
           Use a vault share to recover your vault. Supported file
-          types: .bak & .vult
+          type: .vult
         </Text>
       </View>
     </>
@@ -155,7 +155,7 @@ export default function ImportVault(): React.ReactElement {
           fontType="brockmann-medium"
           style={styles.supportedText}
         >
-          Supported file types: .bak & .vult
+          Supported file type: .vult
         </Text>
       </Animated.View>
 

--- a/src/services/importVaultBackup.ts
+++ b/src/services/importVaultBackup.ts
@@ -78,8 +78,16 @@ function assertImportableFastVault(vault: {
   }
 }
 
+function assertVultFile(fileName: string): void {
+  if (!/\.vult$/i.test(fileName)) {
+    throw new Error(
+      'Unsupported file type. Please select a .vult file.'
+    )
+  }
+}
+
 /**
- * Decodes + validates a vault backup file (.bak / .vult).
+ * Decodes + validates a vault backup file (.vult).
  *
  * If encrypted and no password provided, returns { needsPassword: true }.
  * Otherwise decrypts, validates keyshares, and returns the decoded vault
@@ -90,6 +98,8 @@ export function importVaultBackup({
   fileName,
   password,
 }: ImportVaultBackupInput): ImportVaultBackupResult {
+  assertVultFile(fileName)
+
   const containerBytes = base64.decode(content.trim())
   const container = fromBinary(VaultContainerSchema, containerBytes)
 


### PR DESCRIPTION
## Description

Removes `.bak` from the vault-share import surface.

- only `.vult` files pass the import picker/dev staged-file guard
- `importVaultBackup` now rejects non-`.vult` filenames directly
- updates Add Wallet and Import Vault copy to show `.vult` only

## Verification

- `npm test -- --runTestsByPath __tests__/vault/import-file.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint:check`
- Runtime checked on iPhone 16e simulator with Maestro

## Runtime proof

<a href="https://litter.catbox.moe/oa52t2.png"><img src="https://litter.catbox.moe/oa52t2.png" width="240" /></a>
<a href="https://litter.catbox.moe/qgiae4.png"><img src="https://litter.catbox.moe/qgiae4.png" width="240" /></a>

<img width="240" alt="Screenshot 2026-05-13 at 1 25 40 pm" src="https://github.com/user-attachments/assets/0313b321-e298-475e-9c82-1c8b3288739d" />

