### PR TITLE
fix(storeFastVault): surface name collision instead of silently dropping the new vault

### DIFF
--- a/__tests__/wallet/vault-store.test.ts
+++ b/__tests__/wallet/vault-store.test.ts
@@ -3,7 +3,11 @@ import { base64 } from '@scure/base'
 
 import { __reset as resetSecure } from '../__mocks__/expo-secure-store'
 import { persistImportedVault } from 'services/importVaultBackup'
-import { getStoredVault, storeFastVault } from 'services/migrateToVault'
+import {
+  getStoredVault,
+  storeFastVault,
+  StoreFastVaultNameTakenError,
+} from 'services/migrateToVault'
 import { getAuthData } from 'utils/authData'
 import { VaultSchema } from '../../src/proto/vultisig/vault/v1/vault_pb'
 import { LibType } from '../../src/proto/vultisig/keygen/v1/lib_type_message_pb'
@@ -91,11 +95,13 @@ describe('storeFastVault', () => {
       { publicKey: '02terra', keyshare: 'opaque-terra-share' },
     ])
     expect(
-      restored.chainPublicKeys.map(({ chain, publicKey, isEddsa }) => ({
-        chain,
-        publicKey,
-        isEddsa,
-      }))
+      restored.chainPublicKeys.map(
+        ({ chain, publicKey, isEddsa }) => ({
+          chain,
+          publicKey,
+          isEddsa,
+        })
+      )
     ).toEqual([
       { chain: 'Terra', publicKey: '02terra', isEddsa: false },
     ])
@@ -181,11 +187,13 @@ describe('storeFastVault', () => {
     expect(restored.publicKeyEddsa).toBe('edroot')
     expect(restored.hexChainCode).toBe('2'.repeat(64))
     expect(
-      restored.chainPublicKeys.map(({ chain, publicKey, isEddsa }) => ({
-        chain,
-        publicKey,
-        isEddsa,
-      }))
+      restored.chainPublicKeys.map(
+        ({ chain, publicKey, isEddsa }) => ({
+          chain,
+          publicKey,
+          isEddsa,
+        })
+      )
     ).toEqual([
       { chain: 'Ethereum', publicKey: '02eth', isEddsa: false },
       { chain: 'Terra', publicKey: '02terra', isEddsa: false },
@@ -206,5 +214,45 @@ describe('storeFastVault', () => {
       { publicKey: '02eth', keyshare: 'eth-share' },
       { publicKey: '02terra', keyshare: 'terra-share' },
     ])
+  })
+
+  it('throws StoreFastVaultNameTakenError when a vault with the same name already exists', async () => {
+    // Simulate the bug we hit in production: a vault proto for "Mm" was
+    // left in SecureStore by a prior import attempt. A new seed-import
+    // with the same name used to silently no-op here, routing the user
+    // through the success flow with no wallet to show for it. Now we
+    // throw a typed error so VerifyEmail can surface it via Alert.
+    await storeFastVault('Mm', {
+      publicKey: '02root',
+      publicKeyEcdsa: '02root',
+      publicKeyEddsa: 'edroot',
+      keyshareEcdsa: 'first-ecdsa',
+      keyshareEddsa: 'first-eddsa',
+      chainCode: '2'.repeat(64),
+      localPartyId: 'Device',
+      serverPartyId: 'Server',
+    })
+
+    // Confirm first write landed so the precondition for the bug is real.
+    expect(await getStoredVault('Mm')).toBeTruthy()
+
+    await expect(
+      storeFastVault('Mm', {
+        publicKey: '03other',
+        publicKeyEcdsa: '03other',
+        publicKeyEddsa: 'edother',
+        keyshareEcdsa: 'second-ecdsa',
+        keyshareEddsa: 'second-eddsa',
+        chainCode: '3'.repeat(64),
+        localPartyId: 'Device',
+        serverPartyId: 'Server',
+      })
+    ).rejects.toBeInstanceOf(StoreFastVaultNameTakenError)
+
+    // First vault must remain intact — the failed second call shouldn't
+    // overwrite or corrupt the keyshare of the original.
+    const stored = await getStoredVault('Mm')
+    const restored = fromBinary(VaultSchema, base64.decode(stored!))
+    expect(restored.publicKeyEcdsa).toBe('02root')
   })
 })

--- a/src/services/migrateToVault.ts
+++ b/src/services/migrateToVault.ts
@@ -218,6 +218,26 @@ function terraAddressFromCompressedSecp256k1Hex(
 }
 
 /**
+ * Thrown when storeFastVault refuses to write because another vault is
+ * already stored under the same wallet name. Surfaced verbatim in
+ * VerifyEmail so the user sees "this name is taken" instead of getting
+ * silently dropped into the success flow with no vault in their list.
+ *
+ * Prior behavior silently returned (only logging via console.warn), which
+ * routed the user to BackupVault/MigrationSuccess as if everything worked
+ * — but the freshly-generated MPC keyshare was thrown away and the wallet
+ * never appeared in WalletList.
+ */
+export class StoreFastVaultNameTakenError extends Error {
+  constructor(walletName: string) {
+    super(
+      `A vault named "${walletName}" already exists on this device. Choose a different name and try again.`
+    )
+    this.name = 'StoreFastVaultNameTakenError'
+  }
+}
+
+/**
  * Stores a DKLS fast vault and deletes the legacy auth data entry.
  * Only deletes legacy data after verifying the vault reads back correctly.
  */
@@ -229,11 +249,14 @@ export async function storeFastVault(
     | ImportedSeedFastVaultResult
 ): Promise<void> {
   if ((await getStoredVault(walletName)) !== null) {
-    // eslint-disable-next-line no-console -- important diagnostic for double-migration attempts
-    console.warn(
-      `[storeFastVault] ${walletName} already migrated, skipping`
-    )
-    return
+    // Surface the collision instead of silently dropping the keyshare —
+    // a silent skip routes the user through the success flow with no
+    // wallet to show for it (which is exactly the "I imported but
+    // nothing appears" bug). VerifyEmail's catch block surfaces the
+    // error verbatim via Alert.alert; the user can pick a different
+    // name and retry without losing access (the legacy on-device key
+    // is still intact because authData wasn't touched).
+    throw new StoreFastVaultNameTakenError(walletName)
   }
 
   const isSeedImportVault = 'importedChains' in result


### PR DESCRIPTION
## Summary

Reported in QA: seed-importing a wallet with a name that already had a stored vault proto in SecureStore (e.g. \"Mm\", from prior testing) ran through the full flow — MPC ceremony, email verify, BackupVault, MigrationSuccess — but the new wallet never appeared in WalletList. A cold restart didn't fix it either.

## Root cause

\`storeFastVault\` had a defensive early-return for the \"already migrated\" case that only logged via \`console.warn\`:

\`\`\`ts
if ((await getStoredVault(walletName)) !== null) {
  console.warn(\`[storeFastVault] \${walletName} already migrated, skipping\`)
  return
}
\`\`\`

Silent return meant \`VerifyEmail.tsx:107\`'s \`await storeFastVault(...)\` resolved cleanly, navigation proceeded to BackupVault → MigrationSuccess as if everything had worked, and the freshly-generated MPC keyshare was thrown away. The user reported \"imported but nothing appears, even after restart\" — they were correct.

## Fix

Throw a typed \`StoreFastVaultNameTakenError\` instead. \`VerifyEmail.tsx:113-126\`'s existing catch block already \`Alert.alert\`'s the error message, so the user now sees a clear failure:

> **Could not save vault**
>
> A vault named \"Mm\" already exists on this device. Choose a different name and try again.
>
> Your legacy wallet is unchanged. Please try again.

## Follow-ups (out of scope here)

1. Add a duplicate-name check on the VaultName screen so the user can't get this far in the first place.
2. After the alert, route the user back to VaultName with the typed name pre-filled rather than leaving them stuck on VerifyEmail.

Both are UX improvements that touch UI; intentionally not bundled.

## Verification

- TypeScript clean
- ESLint clean
- Jest **183/183** (23 suites), new test covers both the throw and the invariant that the existing stored vault isn't overwritten by the failed second call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)