### PR TITLE
chore(release): bump version to 5.1.5

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Station",
     "slug": "vultisig",
-    "version": "5.1.4",
+    "version": "5.1.5",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary

- Bump Expo app version from 5.1.4 to 5.1.5 in \`app.json\` ahead of the next iOS + Android EAS production builds.
- Carries via main:
  - PR #117 fast-vault setup reliability (batch-status listener + serial native MPC handles)
  - PR #118 wallet-list SPA-legacy dedup + orphan-proto cleanup on delete
  - PR #120 storeFastVault overwrite policy for orphan / re-imported vaults
- OTA for the same payload already shipped to existing 5.1.4 installs on the production channel.
- Native build numbers (\`ios.buildNumber\`, \`android.versionCode\`) stay EAS-managed (\`appVersionSource: remote\`, \`autoIncrement: true\`).

## Test plan
- [ ] Merge this PR
- [ ] Trigger \`eas build --profile production --platform all\` on \`main\`
- [ ] Confirm both iOS and Android builds report version 5.1.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)