### PR TITLE
chore(release): bump version to 5.1.6

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Station",
     "slug": "vultisig",
-    "version": "5.1.5",
+    "version": "5.1.6",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary

- Bump Expo app version from 5.1.5 to 5.1.6 in \`app.json\` ahead of a new iOS production build.
- Carries via main: PR #122 ripemd160 → hash.js fix for the Android Hermes wallet-list crash.
- The same fix already shipped as an OTA hotfix to live 5.1.4 users on the production channel:
  - iOS: https://expo.dev/accounts/vultisig/projects/vultisig/updates/4828e513-f5f0-4212-b540-1eff8dce25f4
  - Android: https://expo.dev/accounts/vultisig/projects/vultisig/updates/10d031a2-b9bd-4168-adde-ed7e8eacb81a
- Native build numbers stay EAS-managed (\`appVersionSource: remote\`, \`autoIncrement: true\`).

## Test plan
- [ ] Merge this PR
- [ ] Trigger \`eas build --profile production --platform ios\` on \`main\`
- [ ] Confirm the iOS build reports version 5.1.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)