### PR TITLE
fix(import): use Fast Vault terminology in import error messages

### DIFF
--- a/__tests__/vault/import-file.test.ts
+++ b/__tests__/vault/import-file.test.ts
@@ -207,7 +207,7 @@ describe('importVaultBackup — eligibility', () => {
         content,
         fileName: 'multi-share.vult',
       })
-    ).toThrow(/no server-side Vultisig share/i)
+    ).toThrow(/only Fast Vaults are supported/i)
   })
 
   it('rejects server-side vault shares', () => {
@@ -260,6 +260,6 @@ describe('importVaultBackup — eligibility', () => {
         content,
         fileName: 'gg20.vult',
       })
-    ).toThrow(/GG20 vault backups are not supported/i)
+    ).toThrow(/only Fast Vaults are supported/i)
   })
 })

--- a/src/services/importVaultBackup.ts
+++ b/src/services/importVaultBackup.ts
@@ -61,7 +61,7 @@ function assertImportableFastVault(vault: {
   // GG20 is rejected (legacy, different signing math).
   if (vault.libType === LibType.GG20) {
     throw new Error(
-      'GG20 vault backups are not supported. Only DKLS-based vaults can be imported.'
+      'Currently only Fast Vaults are supported. Please import a Fast Vault.'
     )
   }
 
@@ -72,8 +72,13 @@ function assertImportableFastVault(vault: {
   }
 
   if (!vault.signers.some(isServerPartyId)) {
+    // Triggered by Secure Vault backups (2+ device shares, no Vultisig
+    // server signer) and by any other multi-share vault topology that
+    // isn't a Fast Vault. Use Fast/Secure Vault terminology consistently
+    // with the rest of the product instead of describing the underlying
+    // signer-set internals.
     throw new Error(
-      'This vault has no server-side Vultisig share. Multi-share vaults cannot be used in Station.'
+      'Currently only Fast Vaults are supported. Please import a Fast Vault.'
     )
   }
 }


### PR DESCRIPTION
## Summary

paaao flagged in Discord that the error shown when importing a multi-share / Secure Vault backup leaked internal terminology:

> **Import failed**
> This vault has no server-side Vultisig share. Multi-share vaults cannot be used in Station.

Asked to stay inside the Fast/Secure Vault terminology users actually know.

## Fix

Replace with:

> **Import failed**
> Currently only Fast Vaults are supported. Please import a Fast Vault.

Applied to both:
- The multi-share-rejection path in \`importVaultBackup.ts:74-78\` (which triggers on Secure Vault backups and any other vault without a Vultisig server signer)
- The GG20-rejection path in \`importVaultBackup.ts:62-66\` (so the user sees a consistent message regardless of which non-Fast-Vault flavor they tried)

The technical \"server-side vault share\" case (the user trying to import the server's own share) keeps its more specific message because it's a distinct user mistake worth distinguishing.

## Verification

- TypeScript clean
- ESLint clean on changed files
- Jest **186/186** in 23 suites (regex assertions in \`__tests__/vault/import-file.test.ts\` updated to match the new copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)