### PR TITLE
fix(import): accept legacy Station SPA recovery deeplink + bare base64 payload

### DIFF
--- a/__tests__/migration/import-private-key-deeplink.test.ts
+++ b/__tests__/migration/import-private-key-deeplink.test.ts
@@ -1,0 +1,109 @@
+import {
+  createRecoverWalletPayload,
+  createRecoverWalletSchemeUrl,
+  detectRecoveryPayload as detectRecoveryDeeplink,
+} from 'utils/qrCode'
+
+describe('ImportPrivateKey — Station recovery deeplink detection', () => {
+  const fixture: RecoverWalletSchemeDataType = {
+    name: 'fixture-wallet',
+    address: 'terra1fixturefixturefixturefixturefixturefixt',
+    encrypted_key:
+      'a'.repeat(32) + 'b'.repeat(32) + 'ZXhhbXBsZS1jaXBoZXJ0ZXh0',
+  }
+
+  it('parses a Station recovery deeplink emitted by the legacy SPA', () => {
+    const url = createRecoverWalletSchemeUrl(fixture)
+    expect(detectRecoveryDeeplink(url)).toEqual(fixture)
+  })
+
+  it('parses the single-slash deeplink variant (terrastation:wallet_recover/...)', () => {
+    const url = createRecoverWalletSchemeUrl(fixture).replace(
+      'terrastation://',
+      'terrastation:'
+    )
+    expect(detectRecoveryDeeplink(url)).toEqual(fixture)
+  })
+
+  it('returns null for a 64-char hex private key', () => {
+    expect(detectRecoveryDeeplink('a'.repeat(64))).toBeNull()
+  })
+
+  it('returns null when payload base64 decodes to non-JSON', () => {
+    const url = 'terrastation://wallet_recover/?payload=Zm9v' // base64("foo")
+    expect(detectRecoveryDeeplink(url)).toBeNull()
+  })
+
+  it('returns null when payload JSON is missing required keys', () => {
+    const url =
+      'terrastation://wallet_recover/?payload=' +
+      Buffer.from(JSON.stringify({ name: 'x' })).toString('base64')
+    expect(detectRecoveryDeeplink(url)).toBeNull()
+  })
+
+  it('returns null for non-deeplink garbage', () => {
+    expect(detectRecoveryDeeplink('not a key')).toBeNull()
+    expect(detectRecoveryDeeplink('')).toBeNull()
+    expect(detectRecoveryDeeplink('   ')).toBeNull()
+  })
+
+  describe('bare base64 payload (no terrastation:// prefix)', () => {
+    it('parses a payload pasted without the scheme prefix', () => {
+      const payload = createRecoverWalletPayload(fixture)
+      expect(detectRecoveryDeeplink(payload)).toEqual(fixture)
+    })
+
+    it('parses a SPA-shaped payload with the realistic blob length', () => {
+      // Mirrors the bare-base64 paste path reported in the field: users
+      // sometimes copy just the payload portion from the legacy SPA's
+      // "Export wallet" output, not the full terrastation:// URL.
+      //
+      // Build a synthetic payload that matches the SPA's encrypt() output
+      // length (32 hex salt + 32 hex iv + 108-char base64 ciphertext) so
+      // we exercise the same parsing path as a real export, without
+      // checking any real address or ciphertext into the repo.
+      const syntheticPayload = createRecoverWalletPayload({
+        name: 'fixture-wallet',
+        address: 'terra1fixturefixturefixturefixturefixturefixt',
+        encrypted_key:
+          '0'.repeat(32) +
+          '1'.repeat(32) +
+          'AAAA'.repeat(27), // 108 chars, base64-shaped
+      })
+      const result = detectRecoveryDeeplink(syntheticPayload)
+      expect(result).not.toBeNull()
+      expect(result?.name).toBe('fixture-wallet')
+      expect(result?.encrypted_key.length).toBeGreaterThan(64)
+    })
+
+    it('does NOT mistake a 64-char hex private key for a payload', () => {
+      // Hex private keys are 64 chars of [0-9a-fA-F]. They satisfy the
+      // base64 charset (no `=` padding, no `+`/`/`), so the pre-filter has
+      // to let them through; the JSON-parse + shape-check is what rejects.
+      const hexKey = 'a'.repeat(64)
+      expect(detectRecoveryDeeplink(hexKey)).toBeNull()
+      const realisticHex =
+        'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+      expect(detectRecoveryDeeplink(realisticHex)).toBeNull()
+    })
+
+    it('does NOT touch obvious non-base64 text (mnemonic, sentence)', () => {
+      const mnemonic =
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+      expect(detectRecoveryDeeplink(mnemonic)).toBeNull()
+      expect(detectRecoveryDeeplink('hello world')).toBeNull()
+    })
+
+    it('rejects short base64-shaped strings (under floor)', () => {
+      // The pre-filter requires >= 16 chars to bother decoding.
+      expect(detectRecoveryDeeplink('Zm9v')).toBeNull()
+    })
+
+    it('rejects base64 of valid JSON missing required keys', () => {
+      const partial = Buffer.from(
+        JSON.stringify({ name: 'x', address: 'y' })
+      ).toString('base64')
+      expect(detectRecoveryDeeplink(partial)).toBeNull()
+    })
+  })
+})

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Station",
     "slug": "vultisig",
-    "version": "5.1.6",
+    "version": "5.1.7",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/src/navigation/MigrationNavigator.tsx
+++ b/src/navigation/MigrationNavigator.tsx
@@ -77,11 +77,18 @@ export type MigrationStackParams = {
         mode?: MigrationMode
         privateKeyHex?: string
         seedImportChains?: SeedImportChain[]
+        /**
+         * Legacy Station SPA `terrastation://wallet_recover/?payload=...`
+         * URL captured at QR-scan / paste time. Forwarded to
+         * ImportPrivateKey so it can pre-fill and route to LegacyMigrate.
+         */
+        recoveryDeeplink?: string
       }
     | undefined
   ImportWallet: undefined
   ImportPrivateKey: {
     walletName: string
+    recoveryDeeplink?: string
   }
   VaultEmail: {
     walletName: string

--- a/src/screens/migration/ImportPrivateKey.tsx
+++ b/src/screens/migration/ImportPrivateKey.tsx
@@ -20,6 +20,7 @@ import {
   validatePrivateKey,
   type ValidatedPrivateKey,
 } from 'services/privateKeyImport'
+import { detectRecoveryPayload } from 'utils/qrCode'
 
 type Nav = StackNavigationProp<
   MigrationStackParams,
@@ -30,20 +31,30 @@ type Route = RouteProp<MigrationStackParams, 'ImportPrivateKey'>
 export default function ImportPrivateKey(): React.ReactElement {
   const navigation = useNavigation<Nav>()
   const route = useRoute<Route>()
-  const { walletName } = route.params
+  const { walletName, recoveryDeeplink: initialDeeplink } =
+    route.params
   const insets = useSafeAreaInsets()
-  const [value, setValue] = useState('')
+  const [value, setValue] = useState(initialDeeplink ?? '')
+
+  const trimmedValue = value.trim()
+
+  const recoveryDeeplink = useMemo<RecoverWalletSchemeDataType | null>(
+    () => detectRecoveryPayload(trimmedValue),
+    [trimmedValue]
+  )
 
   const validated = useMemo<ValidatedPrivateKey | null>(() => {
-    if (!value.trim()) return null
+    if (!trimmedValue) return null
+    if (recoveryDeeplink) return null
     try {
-      return validatePrivateKey(value)
+      return validatePrivateKey(trimmedValue)
     } catch {
       return null
     }
-  }, [value])
+  }, [trimmedValue, recoveryDeeplink])
 
-  const showError = value.trim().length > 0 && !validated
+  const canContinue = validated !== null || recoveryDeeplink !== null
+  const showError = trimmedValue.length > 0 && !canContinue
 
   return (
     <View style={formStyles.container}>
@@ -63,7 +74,8 @@ export default function ImportPrivateKey(): React.ReactElement {
             Import private key
           </Text>
           <Text style={formStyles.subtitle} fontType="brockmann">
-            This imports a Terra private key only. Use seed phrase
+            Paste a Terra private key, or a Station recovery link
+            exported from the legacy Station app. Use seed phrase
             recovery for a multichain wallet.
           </Text>
 
@@ -81,7 +93,8 @@ export default function ImportPrivateKey(): React.ReactElement {
 
           {showError ? (
             <Text style={styles.errorText} fontType="brockmann">
-              Enter a valid 64-character hex private key.
+              Paste a 64-character hex private key, or a Station
+              recovery link (terrastation://wallet_recover/…).
             </Text>
           ) : null}
 
@@ -102,6 +115,31 @@ export default function ImportPrivateKey(): React.ReactElement {
               </Text>
             </View>
           ) : null}
+
+          {recoveryDeeplink ? (
+            <View style={styles.preview}>
+              <Text
+                fontType="brockmann-medium"
+                style={styles.previewLabel}
+              >
+                Station recovery link detected
+              </Text>
+              <Text
+                fontType="brockmann-medium"
+                style={styles.previewAddress}
+                numberOfLines={1}
+              >
+                {recoveryDeeplink.name}
+              </Text>
+              <Text
+                fontType="brockmann"
+                style={styles.previewAddress}
+                numberOfLines={2}
+              >
+                {recoveryDeeplink.address}
+              </Text>
+            </View>
+          ) : null}
         </Animated.View>
 
         <View
@@ -115,8 +153,16 @@ export default function ImportPrivateKey(): React.ReactElement {
             title="Continue"
             theme="ctaBlue"
             titleFontType="brockmann-medium"
-            disabled={!validated}
+            disabled={!canContinue}
             onPress={() => {
+              if (recoveryDeeplink) {
+                navigation.navigate('LegacyMigrate', {
+                  walletName,
+                  address: recoveryDeeplink.address,
+                  encrypted: recoveryDeeplink.encrypted_key,
+                })
+                return
+              }
               if (!validated) return
               navigation.navigate('VaultEmail', {
                 walletName,

--- a/src/screens/migration/ImportPrivateKey.tsx
+++ b/src/screens/migration/ImportPrivateKey.tsx
@@ -38,10 +38,11 @@ export default function ImportPrivateKey(): React.ReactElement {
 
   const trimmedValue = value.trim()
 
-  const recoveryDeeplink = useMemo<RecoverWalletSchemeDataType | null>(
-    () => detectRecoveryPayload(trimmedValue),
-    [trimmedValue]
-  )
+  const recoveryDeeplink =
+    useMemo<RecoverWalletSchemeDataType | null>(
+      () => detectRecoveryPayload(trimmedValue),
+      [trimmedValue]
+    )
 
   const validated = useMemo<ValidatedPrivateKey | null>(() => {
     if (!trimmedValue) return null

--- a/src/screens/migration/RecoverSeed.tsx
+++ b/src/screens/migration/RecoverSeed.tsx
@@ -39,6 +39,7 @@ import {
   type ImportWalletDiscoveryResult,
 } from 'services/importWalletDiscovery'
 import { validatePrivateKey } from 'services/privateKeyImport'
+import { detectRecoveryPayload } from 'utils/qrCode'
 import {
   validateSeedPhrase,
   type SeedImportChain,
@@ -425,16 +426,25 @@ export default function RecoverSeed(): React.ReactElement {
     () => validateSeedPhrase(seedText),
     [seedText]
   )
+  const recoveryDeeplink = useMemo(() => {
+    const trimmed = privateKeyText.trim()
+    const data = detectRecoveryPayload(trimmed)
+    if (!data) return null
+    return { url: trimmed, data }
+  }, [privateKeyText])
   const privateKey = useMemo(() => {
     if (!privateKeyText.trim()) return null
+    if (recoveryDeeplink) return null
     try {
       return validatePrivateKey(privateKeyText)
     } catch {
       return null
     }
-  }, [privateKeyText])
+  }, [privateKeyText, recoveryDeeplink])
   const showPrivateKeyError =
-    privateKeyText.trim().length > 0 && !privateKey
+    privateKeyText.trim().length > 0 &&
+    !privateKey &&
+    !recoveryDeeplink
 
   // Cancel any in-flight scan if the screen unmounts (back nav, app sleep, etc.).
   useEffect(() => {
@@ -529,6 +539,13 @@ export default function RecoverSeed(): React.ReactElement {
   }
 
   const continuePrivateKey = (): void => {
+    if (recoveryDeeplink) {
+      navigation.navigate('VaultName', {
+        mode: 'import-private-key',
+        recoveryDeeplink: recoveryDeeplink.url,
+      })
+      return
+    }
     if (!privateKey) return
     navigation.navigate('VaultName', {
       mode: 'import-private-key',
@@ -880,7 +897,8 @@ export default function RecoverSeed(): React.ReactElement {
             />
             {showPrivateKeyError ? (
               <Text fontType="brockmann" style={styles.errorText}>
-                Enter a valid 64-character hex private key.
+                Paste a 64-character hex private key, or scan a
+                Station recovery QR code.
               </Text>
             ) : null}
             <View style={styles.utilityRow}>
@@ -914,7 +932,11 @@ export default function RecoverSeed(): React.ReactElement {
           title="Import"
           theme="ctaBlue"
           titleFontType="brockmann-medium"
-          disabled={tab === 'seed' ? !isValidSeed : !privateKey}
+          disabled={
+            tab === 'seed'
+              ? !isValidSeed
+              : !privateKey && !recoveryDeeplink
+          }
           onPress={tab === 'seed' ? scanSeed : continuePrivateKey}
           containerStyle={styles.ctaButton}
           testID="import-wallet-import"

--- a/src/screens/migration/VaultName.tsx
+++ b/src/screens/migration/VaultName.tsx
@@ -33,6 +33,7 @@ export default function VaultName(): React.ReactElement {
   const mode = route.params?.mode ?? 'create'
   const privateKeyHex = route.params?.privateKeyHex
   const seedImportChains = route.params?.seedImportChains
+  const recoveryDeeplink = route.params?.recoveryDeeplink
   const insets = useSafeAreaInsets()
   const [name, setName] = useState('')
 
@@ -105,6 +106,7 @@ export default function VaultName(): React.ReactElement {
               if (mode === 'import-private-key' && !privateKeyHex) {
                 navigation.navigate('ImportPrivateKey', {
                   walletName,
+                  recoveryDeeplink,
                 })
               } else {
                 navigation.navigate('VaultEmail', {

--- a/src/utils/qrCode.ts
+++ b/src/utils/qrCode.ts
@@ -35,3 +35,42 @@ export const createRecoverWalletSchemeUrl = (
   const payload = createRecoverWalletPayload(props)
   return `terrastation://wallet_recover/?payload=${payload}`
 }
+
+// Matches a base64 (incl. URL-safe + padded) string of at least 16 chars.
+// Pre-filter for the bare-payload branch so we don't even attempt to base64
+// decode obvious non-payloads (64-char hex keys, mnemonics with spaces,
+// deeplinks, etc). A real SPA payload is ~250+ chars; 16 is a safe floor.
+const BARE_BASE64_PAYLOAD = /^[A-Za-z0-9+/_=-]{16,}$/
+
+/**
+ * Try to interpret a pasted/scanned string as a Station legacy-SPA wallet
+ * recovery payload. Accepts both shapes the legacy app emits:
+ *   1. `terrastation://wallet_recover/?payload=<base64>` (deeplink / QR)
+ *   2. `<base64>`                                       (bare payload)
+ *
+ * Returns the parsed `{name, address, encrypted_key}` object, or null when
+ * the input is anything else (hex private key, garbage, etc).
+ *
+ * Centralized here so multiple entry points (RecoverSeed, ImportPrivateKey)
+ * stay in sync on what counts as a recovery payload.
+ */
+export const detectRecoveryPayload = (
+  input: string
+): RecoverWalletSchemeDataType | null => {
+  const value = input.trim()
+  if (!value) return null
+
+  if (schemeUrl.recoverWallet.test(value)) {
+    const payload = value.replace(schemeUrl.recoverWallet, '')
+    const data = getRecoverWalletDataFromPayload(payload)
+    if (data && checkIfRecoverWalletQrCodeDataType(data)) return data
+    return null
+  }
+
+  if (BARE_BASE64_PAYLOAD.test(value)) {
+    const data = getRecoverWalletDataFromPayload(value)
+    if (data && checkIfRecoverWalletQrCodeDataType(data)) return data
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary

- Recognize the legacy Station SPA's `terrastation://wallet_recover/?payload=<base64>` recovery deeplink in the private-key import flow — both the full URL (QR scan / paste) and the bare base64 payload variant.
- Route detected payloads through the existing `LegacyMigrate` screen, which prompts for the legacy Station password and decrypts via `decryptLegacyWallet` (already shipping; fixture-validated since 2026-05-10).
- Bumps version to **5.1.7**. No native code touched — same runtime fingerprint, ships as OTA to existing 5.1.4 / 5.1.5 / 5.1.6 installs.

## Why this was broken

Users migrating from the legacy SPA scan/paste a payload like:

```
terrastation://wallet_recover/?payload=eyJuYW1lIjoiZXN0MTIzIiwiYWRkcmVz...
```

or just the bare base64 portion. Both wrap `{name, address, encrypted_key}` JSON with the AES-256-CBC encrypted private key. The screen only accepted 64-char hex, so the QR scanner and paste both failed with *"Paste a 64-character hex private key"*. The decryption logic was already in `src/services/spaLegacyDecrypt.ts` — this PR just wires the input paths to it.

## Security

The `encrypted_key` is **AES-256-CBC + PBKDF2(SHA1, 100 iter)** ciphertext. The password is required in `LegacyMigrate.tsx`, unchanged — `decryptLegacyWallet` throws `WrongPasswordError` on bad password, and on success cross-checks the derived secp256k1 → Terra address against the address embedded in the payload. Nothing decrypts client-side without the legacy Station password.

## Test plan

- [ ] Open Import wallet → Private key tab
- [ ] Scan QR with `terrastation://wallet_recover/?payload=...` payload → Import button enables → name vault → password screen → enter password → lands in VaultEmail
- [ ] Paste the **bare base64 payload** (no `terrastation://` prefix) → same flow
- [ ] Paste a normal 64-char hex private key → existing flow still works
- [ ] Paste a 24-word mnemonic on the Seed tab → still validates as a seed, not as a payload
- [ ] Wrong password on LegacyMigrate → "Wrong password" inline error, no crash
- [ ] Wrong-payload password → address-mismatch error caught before navigating

12 new unit tests cover the parser (both shapes, hex rejection, mnemonic rejection, malformed payloads). 95/95 wallet + migration + vault tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)