### PR TITLE
Stage safe background airdrop registration

### DIFF
--- a/__tests__/services/airdrop-registration.test.ts
+++ b/__tests__/services/airdrop-registration.test.ts
@@ -70,16 +70,17 @@ describe('classifyVaultForAirdropRegistration', () => {
       keyShares: [{ publicKey: ROOT_PUBKEY, keyshare: 'share' }],
     })
 
-    expect(classifyVaultForAirdropRegistration(vault)).toMatchObject({
+    const result = classifyVaultForAirdropRegistration(vault)
+
+    expect(result).toMatchObject({
       status: 'registerable',
       source: 'seed',
       bucket: 'station_migration',
       publicKeyEcdsa: ROOT_PUBKEY,
     })
-    const result = classifyVaultForAirdropRegistration(vault)
-    expect(result.status === 'registerable' && result.recipientAddress).toMatch(
-      /^0x[0-9a-fA-F]{40}$/
-    )
+    expect(
+      result.status === 'registerable' && result.recipientAddress
+    ).toMatch(/^0x[0-9a-fA-F]{40}$/)
   })
 
   it('derives created-vault recipients from the root ECDSA key and chain code', () => {
@@ -102,9 +103,9 @@ describe('classifyVaultForAirdropRegistration', () => {
       bucket: 'campaign_new',
       publicKeyEcdsa: ROOT_PUBKEY,
     })
-    expect(result.status === 'registerable' && result.recipientAddress).toMatch(
-      /^0x[0-9a-fA-F]{40}$/
-    )
+    expect(
+      result.status === 'registerable' && result.recipientAddress
+    ).toMatch(/^0x[0-9a-fA-F]{40}$/)
   })
 
   it('requires provenance before registering non-Station vault shares', () => {
@@ -219,11 +220,15 @@ describe('registerAirdropOnLaunch', () => {
         }),
       })
     )
-    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
-      source: 'seed',
-      bucket: 'station_migration',
-      recipient_address: expect.stringMatching(/^0x[0-9a-fA-F]{40}$/),
-    })
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject(
+      {
+        source: 'seed',
+        bucket: 'station_migration',
+        recipient_address: expect.stringMatching(
+          /^0x[0-9a-fA-F]{40}$/
+        ),
+      }
+    )
 
     const state = await getAirdropRegistrationState()
     expect(state.records[ROOT_PUBKEY.toLowerCase()]).toMatchObject({
@@ -262,9 +267,11 @@ describe('registerAirdropOnLaunch', () => {
       now,
     })
 
-    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
-      source: 'vault_share',
-      bucket: 'campaign_new',
-    })
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject(
+      {
+        source: 'vault_share',
+        bucket: 'campaign_new',
+      }
+    )
   })
 })

--- a/__tests__/services/airdrop-registration.test.ts
+++ b/__tests__/services/airdrop-registration.test.ts
@@ -1,0 +1,270 @@
+import { create, toBinary } from '@bufbuild/protobuf'
+
+import { __reset as resetSecure } from '../__mocks__/expo-secure-store'
+import { LibType } from '../../src/proto/vultisig/keygen/v1/lib_type_message_pb'
+import { VaultSchema } from '../../src/proto/vultisig/vault/v1/vault_pb'
+import {
+  classifyVaultForAirdropRegistration,
+  getAirdropRegistrationState,
+  registerAirdropOnLaunch,
+} from 'services/airdropRegistration'
+import { persistImportedVault } from 'services/importVaultBackup'
+import { storeFastVault } from 'services/migrateToVault'
+
+const ROOT_PUBKEY =
+  '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
+const ETH_PUBKEY =
+  '02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5'
+const CHAIN_CODE =
+  '7923408dadd3c7b56eed15567707ae5e5dca089de972e07f3b860450e2a3b70e'
+
+const now = (): Date => new Date('2026-05-19T00:00:00.000Z')
+
+beforeEach(() => {
+  resetSecure()
+})
+
+describe('classifyVaultForAirdropRegistration', () => {
+  it('blocks legacy Terra-only migrations instead of deriving a phantom EVM recipient', () => {
+    const vault = create(VaultSchema, {
+      name: 'LegacyTerra',
+      publicKeyEcdsa: ROOT_PUBKEY,
+      publicKeyEddsa: '',
+      hexChainCode: '',
+      libType: LibType.KEYIMPORT,
+      signers: ['sdk-test', 'Server-test'],
+      localPartyId: 'sdk-test',
+      chainPublicKeys: [
+        { chain: 'Terra', publicKey: ROOT_PUBKEY, isEddsa: false },
+      ],
+      keyShares: [{ publicKey: ROOT_PUBKEY, keyshare: 'share' }],
+    })
+
+    expect(
+      classifyVaultForAirdropRegistration(vault, {
+        ledger: false,
+        address: 'terra1legacy',
+        encryptedKey: '',
+        password: '',
+        terraOnly: true,
+      })
+    ).toEqual({
+      status: 'blocked',
+      reason: 'legacy_terra_only',
+      publicKeyEcdsa: ROOT_PUBKEY,
+    })
+  })
+
+  it('uses imported Ethereum chain public keys for seed-imported Station vaults', () => {
+    const vault = create(VaultSchema, {
+      name: 'SeedImport',
+      publicKeyEcdsa: ROOT_PUBKEY,
+      publicKeyEddsa: 'edroot',
+      hexChainCode: CHAIN_CODE,
+      libType: LibType.KEYIMPORT,
+      signers: ['sdk-test', 'Server-test'],
+      localPartyId: 'sdk-test',
+      chainPublicKeys: [
+        { chain: 'Ethereum', publicKey: ETH_PUBKEY, isEddsa: false },
+      ],
+      keyShares: [{ publicKey: ROOT_PUBKEY, keyshare: 'share' }],
+    })
+
+    expect(classifyVaultForAirdropRegistration(vault)).toMatchObject({
+      status: 'registerable',
+      source: 'seed',
+      bucket: 'station_migration',
+      publicKeyEcdsa: ROOT_PUBKEY,
+    })
+    const result = classifyVaultForAirdropRegistration(vault)
+    expect(result.status === 'registerable' && result.recipientAddress).toMatch(
+      /^0x[0-9a-fA-F]{40}$/
+    )
+  })
+
+  it('derives created-vault recipients from the root ECDSA key and chain code', () => {
+    const vault = create(VaultSchema, {
+      name: 'Created',
+      publicKeyEcdsa: ROOT_PUBKEY,
+      publicKeyEddsa: 'edroot',
+      hexChainCode: CHAIN_CODE,
+      libType: LibType.DKLS,
+      signers: ['sdk-test', 'Server-test'],
+      localPartyId: 'sdk-test',
+      keyShares: [{ publicKey: ROOT_PUBKEY, keyshare: 'share' }],
+    })
+
+    const result = classifyVaultForAirdropRegistration(vault)
+
+    expect(result).toMatchObject({
+      status: 'registerable',
+      source: 'create',
+      bucket: 'campaign_new',
+      publicKeyEcdsa: ROOT_PUBKEY,
+    })
+    expect(result.status === 'registerable' && result.recipientAddress).toMatch(
+      /^0x[0-9a-fA-F]{40}$/
+    )
+  })
+
+  it('requires provenance before registering non-Station vault shares', () => {
+    const vault = create(VaultSchema, {
+      name: 'Imported',
+      publicKeyEcdsa: ROOT_PUBKEY,
+      publicKeyEddsa: 'edroot',
+      hexChainCode: CHAIN_CODE,
+      libType: LibType.DKLS,
+      signers: ['Device-1', 'Server-1'],
+      localPartyId: 'Device-1',
+      keyShares: [{ publicKey: ROOT_PUBKEY, keyshare: 'share' }],
+    })
+
+    expect(classifyVaultForAirdropRegistration(vault)).toEqual({
+      status: 'blocked',
+      reason: 'unknown_registration_source',
+      publicKeyEcdsa: ROOT_PUBKEY,
+    })
+
+    expect(
+      classifyVaultForAirdropRegistration(vault, {
+        ledger: false,
+        address: '',
+        encryptedKey: '',
+        password: '',
+        airdropSource: 'vault_share',
+      })
+    ).toMatchObject({
+      status: 'registerable',
+      source: 'vault_share',
+      bucket: 'campaign_new',
+    })
+  })
+})
+
+describe('registerAirdropOnLaunch', () => {
+  it('persists missing-auth state and does not call the backend without a token provider', async () => {
+    await storeFastVault('CreatedFastVault', {
+      publicKey: ROOT_PUBKEY,
+      publicKeyEcdsa: ROOT_PUBKEY,
+      publicKeyEddsa: 'edroot',
+      keyshareEcdsa: 'ecdsa-share',
+      keyshareEddsa: 'eddsa-share',
+      chainCode: CHAIN_CODE,
+      localPartyId: 'sdk-test',
+      serverPartyId: 'Server-test',
+    })
+    const fetchMock = jest.fn()
+
+    const first = await registerAirdropOnLaunch({
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      now,
+    })
+    const second = await registerAirdropOnLaunch({
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      now,
+    })
+
+    expect(first).toMatchObject({ considered: 1, blocked: 1 })
+    expect(second).toMatchObject({ considered: 1, skipped: 1 })
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    const state = await getAirdropRegistrationState()
+    expect(state.records[ROOT_PUBKEY.toLowerCase()]).toMatchObject({
+      status: 'blocked',
+      reason: 'missing_auth_token',
+      source: 'create',
+      bucket: 'campaign_new',
+    })
+  })
+
+  it('posts authenticated registrations and records success', async () => {
+    await storeFastVault('SeedImport', {
+      publicKey: ROOT_PUBKEY,
+      publicKeyEcdsa: ROOT_PUBKEY,
+      publicKeyEddsa: 'edroot',
+      keyshareEcdsa: 'root-ecdsa-share',
+      keyshareEddsa: 'root-eddsa-share',
+      chainCode: CHAIN_CODE,
+      localPartyId: 'sdk-test',
+      serverPartyId: 'Server-test',
+      importedChains: [
+        {
+          chain: 'Ethereum',
+          publicKey: ETH_PUBKEY,
+          keyshare: '',
+          isEddsa: false,
+        },
+      ],
+    })
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: jest.fn(),
+    })
+
+    const summary = await registerAirdropOnLaunch({
+      getAuthToken: jest.fn().mockResolvedValue('jwt'),
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      now,
+    })
+
+    expect(summary).toMatchObject({ considered: 1, registered: 1 })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://agent.vultisig.com/airdrop/register',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer jwt',
+          'Content-Type': 'application/json',
+        }),
+      })
+    )
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+      source: 'seed',
+      bucket: 'station_migration',
+      recipient_address: expect.stringMatching(/^0x[0-9a-fA-F]{40}$/),
+    })
+
+    const state = await getAirdropRegistrationState()
+    expect(state.records[ROOT_PUBKEY.toLowerCase()]).toMatchObject({
+      status: 'registered',
+      source: 'seed',
+      bucket: 'station_migration',
+    })
+  })
+
+  it('uses vault-share provenance persisted for imported backups', async () => {
+    const vault = create(VaultSchema, {
+      name: 'ImportedVault',
+      publicKeyEcdsa: ROOT_PUBKEY,
+      publicKeyEddsa: 'edroot',
+      hexChainCode: CHAIN_CODE,
+      libType: LibType.DKLS,
+      signers: ['Device-1', 'Server-1'],
+      localPartyId: 'Device-1',
+      keyShares: [{ publicKey: ROOT_PUBKEY, keyshare: 'share' }],
+    })
+
+    await persistImportedVault(
+      toBinary(VaultSchema, vault),
+      'ImportedVault'
+    )
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: jest.fn(),
+    })
+
+    await registerAirdropOnLaunch({
+      getAuthToken: jest.fn().mockResolvedValue('jwt'),
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      now,
+    })
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+      source: 'vault_share',
+      bucket: 'campaign_new',
+    })
+  })
+})

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -37,6 +37,7 @@ import keystore, { KeystoreEnum } from 'nativeModules/keystore'
 import { settings } from 'utils/storage'
 import { migrateLegacyKeystore } from 'utils/legacyMigration'
 import { backfillTerraOnlyFlag } from 'services/migrateToVault'
+import { registerAirdropOnLaunch } from 'services/airdropRegistration'
 
 import DebugBanner from './DebugBanner'
 import GlobalTopNotification from './GlobalTopNotification'
@@ -212,6 +213,12 @@ export default (): ReactElement => {
         settings.get(),
       ])
       setLocal(loaded)
+      registerAirdropOnLaunch().catch((err) => {
+        if (__DEV__) {
+          // eslint-disable-next-line no-console
+          console.warn('[Airdrop] launch registration skipped:', err)
+        }
+      })
     }
 
     startup()

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,4 +1,7 @@
 export const env = {
+  agentBackendUrl:
+    process.env.EXPO_PUBLIC_AGENT_BACKEND_URL ??
+    'https://agent.vultisig.com',
   relayUrl: 'https://api.vultisig.com/router',
   vultisigApiUrl: 'https://api.vultisig.com',
 } as const

--- a/src/nativeModules/preferences.ts
+++ b/src/nativeModules/preferences.ts
@@ -16,6 +16,7 @@ export enum PreferencesEnum {
   vaultsUpgraded = 'vaultsUpgraded',
   terraOnlyBackfilled = 'terraOnlyBackfilled',
   terraOnlyBackfilledV2 = 'terraOnlyBackfilledV2',
+  airdropRegistrationState = 'airdropRegistrationState',
 }
 
 export type PreferencesType = {

--- a/src/services/airdropRegistration.ts
+++ b/src/services/airdropRegistration.ts
@@ -254,11 +254,14 @@ function classifyWithSource(
   vault: Vault,
   source: AirdropRegistrationSource
 ): AirdropVaultClassification {
-  const recipient =
-    source === 'create'
-      ? deriveCreatedVaultRecipient(vault)
-      : deriveImportedEvmRecipient(vault) ||
-        deriveCreatedVaultRecipient(vault)
+  let recipient: string | null
+  if (source === 'create') {
+    recipient = deriveCreatedVaultRecipient(vault)
+  } else {
+    recipient =
+      deriveImportedEvmRecipient(vault) ||
+      deriveCreatedVaultRecipient(vault)
+  }
 
   if (!recipient) {
     return {
@@ -447,10 +450,9 @@ function parseErrorCode(body: string): string | null {
 function classifyHttpFailure(
   status: number,
   body: string
-): {
-  status: 'blocked' | 'failed'
-  reason: AirdropBlockedReason | string
-} {
+):
+  | { status: 'blocked'; reason: AirdropBlockedReason }
+  | { status: 'failed'; reason: string } {
   const code = parseErrorCode(body)
   if (status === 401) {
     return { status: 'failed', reason: 'auth_failed' }
@@ -610,19 +612,23 @@ export async function registerAirdropOnLaunch({
         response.body
       )
 
-      state.records[key] =
-        failure.status === 'blocked'
-          ? blockedRecord(
-              walletName,
-              publicKeyEcdsa,
-              failure.reason as AirdropBlockedReason,
-              currentTime,
-              candidate
-            )
-          : failedRecord(candidate, failure.reason, currentTime)
-      summary[
-        failure.status === 'blocked' ? 'blocked' : 'failed'
-      ] += 1
+      if (failure.status === 'blocked') {
+        state.records[key] = blockedRecord(
+          walletName,
+          publicKeyEcdsa,
+          failure.reason,
+          currentTime,
+          candidate
+        )
+        summary.blocked += 1
+      } else {
+        state.records[key] = failedRecord(
+          candidate,
+          failure.reason,
+          currentTime
+        )
+        summary.failed += 1
+      }
     } catch (error) {
       state.records[key] = failedRecord(
         candidate,

--- a/src/services/airdropRegistration.ts
+++ b/src/services/airdropRegistration.ts
@@ -1,0 +1,638 @@
+import { fromBinary } from '@bufbuild/protobuf'
+import { secp256k1 } from '@noble/curves/secp256k1.js'
+import { hmac } from '@noble/hashes/hmac.js'
+import { sha512 } from '@noble/hashes/sha2.js'
+import { keccak_256 } from '@noble/hashes/sha3.js'
+import { base64 } from '@scure/base'
+
+import { env } from '../config/env'
+import { LibType } from '../proto/vultisig/keygen/v1/lib_type_message_pb'
+import type { Vault } from '../proto/vultisig/vault/v1/vault_pb'
+import { VaultSchema } from '../proto/vultisig/vault/v1/vault_pb'
+import preferences, {
+  PreferencesEnum,
+} from '../nativeModules/preferences'
+import {
+  getAuthData,
+  type AuthDataValueType,
+  type LedgerDataValueType,
+} from '../utils/authData'
+import { bytesToHex, hexToBytes } from '../utils/mpcCrypto'
+import { getStoredVault } from './migrateToVault'
+
+export type AirdropRegistrationSource =
+  | 'seed'
+  | 'vault_share'
+  | 'create'
+export type AirdropBucket = 'station_migration' | 'campaign_new'
+
+export type AirdropRegistrationPayload = {
+  source: AirdropRegistrationSource
+  bucket: AirdropBucket
+  recipient_address: string
+}
+
+export type AirdropRegistrationCandidate =
+  AirdropRegistrationPayload & {
+    walletName: string
+    publicKeyEcdsa: string
+  }
+
+export type AirdropBlockedReason =
+  | 'invalid_vault'
+  | 'legacy_terra_only'
+  | 'missing_auth_token'
+  | 'missing_trustworthy_evm_recipient'
+  | 'registration_rejected'
+  | 'registration_window_closed'
+  | 'unknown_registration_source'
+
+export type AirdropVaultClassification =
+  | {
+      status: 'registerable'
+      source: AirdropRegistrationSource
+      bucket: AirdropBucket
+      recipientAddress: string
+      publicKeyEcdsa: string
+    }
+  | {
+      status: 'blocked'
+      reason: AirdropBlockedReason
+      publicKeyEcdsa?: string
+    }
+
+export type AirdropRegistrationRecord = {
+  status: 'registered' | 'blocked' | 'failed'
+  walletName: string
+  publicKeyEcdsa: string
+  source?: AirdropRegistrationSource
+  bucket?: AirdropBucket
+  recipientAddress?: string
+  reason?: AirdropBlockedReason | string
+  updatedAt: string
+  nextRetryAt?: string
+}
+
+export type AirdropRegistrationState = {
+  version: 1
+  records: Record<string, AirdropRegistrationRecord>
+}
+
+export type AirdropRegistrationSummary = {
+  considered: number
+  registered: number
+  blocked: number
+  failed: number
+  skipped: number
+}
+
+type AuthEntry = AuthDataValueType | LedgerDataValueType
+
+type RegisterAirdropOnLaunchOptions = {
+  getAuthToken?: (
+    candidate: AirdropRegistrationCandidate
+  ) => Promise<string | null>
+  fetchImpl?: typeof fetch
+  now?: () => Date
+}
+
+const AIRDROP_RETRY_MS = 24 * 60 * 60 * 1000
+const DEFAULT_STATE: AirdropRegistrationState = {
+  version: 1,
+  records: {},
+}
+
+const getCurrentDate = (): Date => new Date()
+
+function normalizeCompressedPublicKeyHex(
+  value: string
+): string | null {
+  const clean = value.replace(/^0x/i, '')
+  if (!/^0[23][0-9a-fA-F]{64}$/.test(clean)) return null
+  return clean.toLowerCase()
+}
+
+function normalizeChainCodeHex(value: string): string | null {
+  const clean = value.replace(/^0x/i, '')
+  if (!/^[0-9a-fA-F]{64}$/.test(clean)) return null
+  if (clean === '0'.repeat(64)) return null
+  return clean.toLowerCase()
+}
+
+function toChecksumAddress(addressHex: string): string {
+  const lower = addressHex.replace(/^0x/i, '').toLowerCase()
+  const hash = bytesToHex(keccak_256(new TextEncoder().encode(lower)))
+  let out = '0x'
+  for (let i = 0; i < lower.length; i++) {
+    out +=
+      parseInt(hash[i], 16) >= 8 ? lower[i].toUpperCase() : lower[i]
+  }
+  return out
+}
+
+function ethAddressFromCompressedPublicKey(
+  publicKeyHex: string
+): string | null {
+  const clean = normalizeCompressedPublicKeyHex(publicKeyHex)
+  if (!clean) return null
+
+  try {
+    const point = secp256k1.Point.fromHex(clean)
+    const uncompressed = point.toBytes(false)
+    const hash = keccak_256(uncompressed.slice(1))
+    return toChecksumAddress(bytesToHex(hash.slice(-20)))
+  } catch {
+    return null
+  }
+}
+
+function deriveChildPublicKey(
+  parentPublicKey: Uint8Array,
+  parentChainCode: Uint8Array,
+  index: number
+): { publicKey: Uint8Array; chainCode: Uint8Array } {
+  const data = new Uint8Array(37)
+  data.set(parentPublicKey, 0)
+  data[33] = (index >>> 24) & 0xff
+  data[34] = (index >>> 16) & 0xff
+  data[35] = (index >>> 8) & 0xff
+  data[36] = index & 0xff
+
+  const digest = hmac(sha512, parentChainCode, data)
+  const tweak = BigInt(`0x${bytesToHex(digest.slice(0, 32))}`)
+  const childPoint = secp256k1.Point.fromHex(
+    bytesToHex(parentPublicKey)
+  ).add(secp256k1.Point.BASE.multiply(tweak))
+
+  return {
+    publicKey: childPoint.toBytes(true),
+    chainCode: digest.slice(32),
+  }
+}
+
+function deriveCreatedVaultRecipient(vault: Vault): string | null {
+  const publicKey = normalizeCompressedPublicKeyHex(
+    vault.publicKeyEcdsa
+  )
+  const chainCode = normalizeChainCodeHex(vault.hexChainCode)
+  if (!publicKey || !chainCode) return null
+
+  try {
+    let childPublicKey = hexToBytes(publicKey)
+    let childChainCode = hexToBytes(chainCode)
+    for (const index of [44, 60, 0, 0, 0]) {
+      const child = deriveChildPublicKey(
+        childPublicKey,
+        childChainCode,
+        index
+      )
+      childPublicKey = child.publicKey
+      childChainCode = child.chainCode
+    }
+    return ethAddressFromCompressedPublicKey(
+      bytesToHex(childPublicKey)
+    )
+  } catch {
+    return null
+  }
+}
+
+function deriveImportedEvmRecipient(vault: Vault): string | null {
+  const ethereumKey = vault.chainPublicKeys.find(
+    (entry) => entry.chain === 'Ethereum' && !entry.isEddsa
+  )
+  if (!ethereumKey?.publicKey) return null
+  return ethAddressFromCompressedPublicKey(ethereumKey.publicKey)
+}
+
+function isStationMobileVault(vault: Vault): boolean {
+  return vault.localPartyId.toLowerCase().startsWith('sdk-')
+}
+
+function isNonLedgerAuthEntry(
+  entry?: AuthEntry
+): entry is AuthDataValueType {
+  return !!entry && entry.ledger !== true
+}
+
+function hasServerSigner(vault: Vault): boolean {
+  return vault.signers.some((signer) =>
+    signer.toLowerCase().startsWith('server-')
+  )
+}
+
+function isLegacyTerraOnly(
+  vault: Vault,
+  authEntry?: AuthEntry
+): boolean {
+  if (isNonLedgerAuthEntry(authEntry) && authEntry.terraOnly) {
+    return true
+  }
+
+  const hasOnlyTerraChains =
+    vault.chainPublicKeys.length > 0 &&
+    vault.chainPublicKeys.every(
+      (entry) =>
+        entry.chain === 'Terra' || entry.chain === 'TerraClassic'
+    )
+
+  return (
+    vault.libType === LibType.KEYIMPORT &&
+    hasOnlyTerraChains &&
+    !vault.publicKeyEddsa &&
+    !normalizeChainCodeHex(vault.hexChainCode)
+  )
+}
+
+function bucketForSource(
+  source: AirdropRegistrationSource
+): AirdropBucket {
+  return source === 'seed' ? 'station_migration' : 'campaign_new'
+}
+
+function classifyWithSource(
+  vault: Vault,
+  source: AirdropRegistrationSource
+): AirdropVaultClassification {
+  const recipient =
+    source === 'create'
+      ? deriveCreatedVaultRecipient(vault)
+      : deriveImportedEvmRecipient(vault) ||
+        deriveCreatedVaultRecipient(vault)
+
+  if (!recipient) {
+    return {
+      status: 'blocked',
+      reason: 'missing_trustworthy_evm_recipient',
+      publicKeyEcdsa: vault.publicKeyEcdsa,
+    }
+  }
+
+  return {
+    status: 'registerable',
+    source,
+    bucket: bucketForSource(source),
+    recipientAddress: recipient,
+    publicKeyEcdsa: vault.publicKeyEcdsa,
+  }
+}
+
+export function classifyVaultForAirdropRegistration(
+  vault: Vault,
+  authEntry?: AuthEntry
+): AirdropVaultClassification {
+  if (!normalizeCompressedPublicKeyHex(vault.publicKeyEcdsa)) {
+    return { status: 'blocked', reason: 'invalid_vault' }
+  }
+
+  if (isLegacyTerraOnly(vault, authEntry)) {
+    return {
+      status: 'blocked',
+      reason: 'legacy_terra_only',
+      publicKeyEcdsa: vault.publicKeyEcdsa,
+    }
+  }
+
+  if (isNonLedgerAuthEntry(authEntry) && authEntry.airdropSource) {
+    return classifyWithSource(vault, authEntry.airdropSource)
+  }
+
+  if (!isStationMobileVault(vault) || !hasServerSigner(vault)) {
+    return {
+      status: 'blocked',
+      reason: 'unknown_registration_source',
+      publicKeyEcdsa: vault.publicKeyEcdsa,
+    }
+  }
+
+  if (vault.libType === LibType.DKLS) {
+    return classifyWithSource(vault, 'create')
+  }
+
+  if (vault.libType === LibType.KEYIMPORT && vault.publicKeyEddsa) {
+    return classifyWithSource(vault, 'seed')
+  }
+
+  return {
+    status: 'blocked',
+    reason: 'missing_trustworthy_evm_recipient',
+    publicKeyEcdsa: vault.publicKeyEcdsa,
+  }
+}
+
+function registrationKey(publicKeyEcdsa: string): string {
+  return publicKeyEcdsa.toLowerCase()
+}
+
+export async function getAirdropRegistrationState(): Promise<AirdropRegistrationState> {
+  const raw = await preferences.getString(
+    PreferencesEnum.airdropRegistrationState
+  )
+  if (!raw) return { ...DEFAULT_STATE, records: {} }
+
+  try {
+    const parsed = JSON.parse(raw) as AirdropRegistrationState
+    if (parsed.version === 1 && parsed.records) return parsed
+  } catch {}
+
+  return { ...DEFAULT_STATE, records: {} }
+}
+
+async function setAirdropRegistrationState(
+  state: AirdropRegistrationState
+): Promise<void> {
+  await preferences.setString(
+    PreferencesEnum.airdropRegistrationState,
+    JSON.stringify(state)
+  )
+}
+
+function isRetryDue(
+  record: AirdropRegistrationRecord,
+  now: Date
+): boolean {
+  if (!record.nextRetryAt) return true
+  return Date.parse(record.nextRetryAt) <= now.getTime()
+}
+
+function shouldSkipRecord(
+  record: AirdropRegistrationRecord | undefined,
+  now: Date,
+  hasAuthTokenProvider: boolean
+): boolean {
+  if (!record) return false
+  if (record.status === 'registered') return true
+
+  if (
+    record.status === 'blocked' &&
+    record.reason === 'missing_auth_token'
+  ) {
+    return !hasAuthTokenProvider && !isRetryDue(record, now)
+  }
+
+  if (record.status === 'blocked') return true
+  return !isRetryDue(record, now)
+}
+
+function retryAt(now: Date): string {
+  return new Date(now.getTime() + AIRDROP_RETRY_MS).toISOString()
+}
+
+function blockedRecord(
+  walletName: string,
+  publicKeyEcdsa: string,
+  reason: AirdropBlockedReason,
+  now: Date,
+  candidate?: Partial<AirdropRegistrationCandidate>
+): AirdropRegistrationRecord {
+  return {
+    status: 'blocked',
+    walletName,
+    publicKeyEcdsa,
+    source: candidate?.source,
+    bucket: candidate?.bucket,
+    recipientAddress: candidate?.recipient_address,
+    reason,
+    updatedAt: now.toISOString(),
+    nextRetryAt:
+      reason === 'missing_auth_token' ? retryAt(now) : undefined,
+  }
+}
+
+function failedRecord(
+  candidate: AirdropRegistrationCandidate,
+  reason: string,
+  now: Date
+): AirdropRegistrationRecord {
+  return {
+    status: 'failed',
+    walletName: candidate.walletName,
+    publicKeyEcdsa: candidate.publicKeyEcdsa,
+    source: candidate.source,
+    bucket: candidate.bucket,
+    recipientAddress: candidate.recipient_address,
+    reason,
+    updatedAt: now.toISOString(),
+    nextRetryAt: retryAt(now),
+  }
+}
+
+function registeredRecord(
+  candidate: AirdropRegistrationCandidate,
+  now: Date
+): AirdropRegistrationRecord {
+  return {
+    status: 'registered',
+    walletName: candidate.walletName,
+    publicKeyEcdsa: candidate.publicKeyEcdsa,
+    source: candidate.source,
+    bucket: candidate.bucket,
+    recipientAddress: candidate.recipient_address,
+    updatedAt: now.toISOString(),
+  }
+}
+
+function parseErrorCode(body: string): string | null {
+  try {
+    const parsed = JSON.parse(body) as {
+      error?: unknown
+      code?: unknown
+    }
+    if (typeof parsed.error === 'string') return parsed.error
+    if (typeof parsed.code === 'string') return parsed.code
+  } catch {}
+  return null
+}
+
+function classifyHttpFailure(
+  status: number,
+  body: string
+): {
+  status: 'blocked' | 'failed'
+  reason: AirdropBlockedReason | string
+} {
+  const code = parseErrorCode(body)
+  if (status === 401) {
+    return { status: 'failed', reason: 'auth_failed' }
+  }
+  if (status === 403 && code === 'WINDOW_CLOSED') {
+    return {
+      status: 'blocked',
+      reason: 'registration_window_closed',
+    }
+  }
+  if (status >= 400 && status < 500) {
+    return { status: 'blocked', reason: 'registration_rejected' }
+  }
+  return { status: 'failed', reason: code ?? `http_${status}` }
+}
+
+async function postAirdropRegistration(
+  token: string,
+  candidate: AirdropRegistrationCandidate,
+  fetchImpl: typeof fetch
+): Promise<
+  { ok: true } | { ok: false; status: number; body: string }
+> {
+  const res = await fetchImpl(
+    `${env.agentBackendUrl}/airdrop/register`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        source: candidate.source,
+        bucket: candidate.bucket,
+        recipient_address: candidate.recipient_address,
+      }),
+    }
+  )
+
+  if (!res.ok) {
+    return {
+      ok: false,
+      status: res.status,
+      body: await res.text(),
+    }
+  }
+
+  return { ok: true }
+}
+
+async function readStoredVault(
+  walletName: string
+): Promise<Vault | null> {
+  const raw = await getStoredVault(walletName)
+  if (!raw) return null
+  try {
+    return fromBinary(VaultSchema, base64.decode(raw))
+  } catch {
+    return null
+  }
+}
+
+export async function registerAirdropOnLaunch({
+  getAuthToken,
+  fetchImpl = fetch,
+  now = getCurrentDate,
+}: RegisterAirdropOnLaunchOptions = {}): Promise<AirdropRegistrationSummary> {
+  const summary: AirdropRegistrationSummary = {
+    considered: 0,
+    registered: 0,
+    blocked: 0,
+    failed: 0,
+    skipped: 0,
+  }
+  const state = await getAirdropRegistrationState()
+  const authData = await getAuthData()
+  const hasAuthTokenProvider = typeof getAuthToken === 'function'
+
+  for (const [walletName, authEntry] of Object.entries(
+    authData ?? {}
+  )) {
+    if (authEntry.ledger) continue
+
+    const vault = await readStoredVault(walletName)
+    if (!vault) continue
+
+    const currentTime = now()
+    const classification = classifyVaultForAirdropRegistration(
+      vault,
+      authEntry
+    )
+    const publicKeyEcdsa =
+      classification.publicKeyEcdsa || vault.publicKeyEcdsa
+
+    if (!publicKeyEcdsa) continue
+    summary.considered += 1
+
+    const key = registrationKey(publicKeyEcdsa)
+    const existing = state.records[key]
+    if (
+      shouldSkipRecord(existing, currentTime, hasAuthTokenProvider)
+    ) {
+      summary.skipped += 1
+      continue
+    }
+
+    if (classification.status === 'blocked') {
+      state.records[key] = blockedRecord(
+        walletName,
+        publicKeyEcdsa,
+        classification.reason,
+        currentTime
+      )
+      summary.blocked += 1
+      continue
+    }
+
+    const candidate: AirdropRegistrationCandidate = {
+      walletName,
+      publicKeyEcdsa,
+      source: classification.source,
+      bucket: classification.bucket,
+      recipient_address: classification.recipientAddress,
+    }
+
+    const token = hasAuthTokenProvider
+      ? await getAuthToken(candidate)
+      : null
+
+    if (!token) {
+      state.records[key] = blockedRecord(
+        walletName,
+        publicKeyEcdsa,
+        'missing_auth_token',
+        currentTime,
+        candidate
+      )
+      summary.blocked += 1
+      continue
+    }
+
+    try {
+      const response = await postAirdropRegistration(
+        token,
+        candidate,
+        fetchImpl
+      )
+
+      if (response.ok === true) {
+        state.records[key] = registeredRecord(candidate, currentTime)
+        summary.registered += 1
+        continue
+      }
+
+      const failure = classifyHttpFailure(
+        response.status,
+        response.body
+      )
+
+      state.records[key] =
+        failure.status === 'blocked'
+          ? blockedRecord(
+              walletName,
+              publicKeyEcdsa,
+              failure.reason as AirdropBlockedReason,
+              currentTime,
+              candidate
+            )
+          : failedRecord(candidate, failure.reason, currentTime)
+      summary[
+        failure.status === 'blocked' ? 'blocked' : 'failed'
+      ] += 1
+    } catch (error) {
+      state.records[key] = failedRecord(
+        candidate,
+        error instanceof Error ? error.message : String(error),
+        currentTime
+      )
+      summary.failed += 1
+    }
+  }
+
+  await setAirdropRegistrationState(state)
+  return summary
+}

--- a/src/services/importVaultBackup.ts
+++ b/src/services/importVaultBackup.ts
@@ -176,6 +176,7 @@ export async function persistImportedVault(
         encryptedKey: '',
         password: '',
         ledger: false,
+        airdropSource: 'vault_share',
       },
     },
   })

--- a/src/services/migrateToVault.ts
+++ b/src/services/migrateToVault.ts
@@ -311,11 +311,17 @@ export async function storeFastVault(
   const isSeedImportVault = 'importedChains' in result
   const isCreatedVault =
     'publicKeyEddsa' in result && !isSeedImportVault
-  const airdropSource = isSeedImportVault
-    ? 'seed'
-    : isCreatedVault
-    ? 'create'
-    : undefined
+  const isSingleKeyImport = !isCreatedVault && !isSeedImportVault
+  let airdropSource: AuthDataValueType['airdropSource']
+  if (isSeedImportVault) {
+    airdropSource = 'seed'
+  } else if (isCreatedVault) {
+    airdropSource = 'create'
+  }
+  const authMetadata = {
+    ...(airdropSource ? { airdropSource } : {}),
+    ...(isSingleKeyImport ? { terraOnly: true } : {}),
+  }
   const legacyResult = result as KeyImportResult
 
   const vault = isSeedImportVault
@@ -434,10 +440,7 @@ export async function storeFastVault(
           encryptedKey: '',
           password: '',
           ledger: false,
-          ...(airdropSource ? { airdropSource } : {}),
-          ...(!isCreatedVault && !isSeedImportVault
-            ? { terraOnly: true }
-            : {}),
+          ...authMetadata,
         },
       },
     })
@@ -464,16 +467,13 @@ export async function storeFastVault(
         [walletName]: {
           address: isSeedImportVault
             ? seedImportTerraAddress
-            : !isCreatedVault
+            : isSingleKeyImport
             ? legacyResult.terraAddress
             : '',
           encryptedKey: '',
           password: '',
           ledger: false,
-          ...(airdropSource ? { airdropSource } : {}),
-          ...(!isCreatedVault && !isSeedImportVault
-            ? { terraOnly: true }
-            : {}),
+          ...authMetadata,
         },
       },
     })

--- a/src/services/migrateToVault.ts
+++ b/src/services/migrateToVault.ts
@@ -311,6 +311,11 @@ export async function storeFastVault(
   const isSeedImportVault = 'importedChains' in result
   const isCreatedVault =
     'publicKeyEddsa' in result && !isSeedImportVault
+  const airdropSource = isSeedImportVault
+    ? 'seed'
+    : isCreatedVault
+    ? 'create'
+    : undefined
   const legacyResult = result as KeyImportResult
 
   const vault = isSeedImportVault
@@ -429,6 +434,7 @@ export async function storeFastVault(
           encryptedKey: '',
           password: '',
           ledger: false,
+          ...(airdropSource ? { airdropSource } : {}),
           ...(!isCreatedVault && !isSeedImportVault
             ? { terraOnly: true }
             : {}),
@@ -464,6 +470,7 @@ export async function storeFastVault(
           encryptedKey: '',
           password: '',
           ledger: false,
+          ...(airdropSource ? { airdropSource } : {}),
           ...(!isCreatedVault && !isSeedImportVault
             ? { terraOnly: true }
             : {}),

--- a/src/utils/authData.ts
+++ b/src/utils/authData.ts
@@ -7,6 +7,7 @@ export type AuthDataValueType = {
   address: string
   password: string
   terraOnly?: boolean
+  airdropSource?: 'seed' | 'vault_share' | 'create'
 }
 
 export type LedgerDataValueType = {


### PR DESCRIPTION
## Description

Adds a safe Station Mobile airdrop registration path that runs on launch but does not call `/airdrop/register` without a real JWT.

- Classifies stored Vultisig vaults into the agent-backend source/bucket format.
- Derives an EVM recipient only from created-vault root keys + chain code or seed-imported Ethereum chain public keys.
- Blocks legacy Terra-only migrations and unknown imported vaults instead of inventing a recipient/source.
- Persists per-public-key registration state with retry throttling.
- Stamps future created/seed/vault-share provenance in authData.

## Blocker

Full background registration for existing users is still blocked: Station Mobile does not persist or silently recover the VultiServer vault password needed by the backend `/auth/token` flow. The launch hook records `missing_auth_token` and skips backend calls until a token provider is wired.

Required follow-up: reuse/port the Vultiagent auth flow with a safe silent token source, or add a backend-supported silent auth contract. This PR does not add an unauthenticated registration path.

## Verification

- `npm run typecheck`
- `npm test -- __tests__/services/airdrop-registration.test.ts __tests__/wallet/vault-store.test.ts __tests__/vault/import-file.test.ts --runInBand`

## Receipts

No screenshotable UI was added. This is a background launch hook, and the visible behavior is unchanged until a valid silent token provider exists.
